### PR TITLE
일기장 [STEP 2] 두기, marisol

### DIFF
--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		B32FEFA228600F5600F3A6B5 /* Model.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = B32FEFA028600F5600F3A6B5 /* Model.xcdatamodeld */; };
 		B32FEFA52860116500F3A6B5 /* DiaryModel+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = B32FEFA32860116500F3A6B5 /* DiaryModel+CoreDataClass.swift */; };
 		B32FEFA62860116500F3A6B5 /* DiaryModel+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = B32FEFA42860116500F3A6B5 /* DiaryModel+CoreDataProperties.swift */; };
+		B3D761702860131C00C4AE94 /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D7616F2860131C00C4AE94 /* CoreDataManager.swift */; };
 		B3FB2B2B285C1EC6009A932C /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FB2B2A285C1EC6009A932C /* Date+.swift */; };
 		B3FE9B39285820680006A7AB /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FE9B38285820680006A7AB /* MainView.swift */; };
 		B3FE9B3B285853F60006A7AB /* DiaryData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FE9B3A285853F60006A7AB /* DiaryData.swift */; };
@@ -38,6 +39,7 @@
 		B32FEFA128600F5600F3A6B5 /* Model.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model.xcdatamodel; sourceTree = "<group>"; };
 		B32FEFA32860116500F3A6B5 /* DiaryModel+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiaryModel+CoreDataClass.swift"; sourceTree = "<group>"; };
 		B32FEFA42860116500F3A6B5 /* DiaryModel+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiaryModel+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		B3D7616F2860131C00C4AE94 /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
 		B3FB2B2A285C1EC6009A932C /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		B3FE9B38285820680006A7AB /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
 		B3FE9B3A285853F60006A7AB /* DiaryData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryData.swift; sourceTree = "<group>"; };
@@ -107,6 +109,7 @@
 			isa = PBXGroup;
 			children = (
 				B3FE9B3A285853F60006A7AB /* DiaryData.swift */,
+				B3D7616F2860131C00C4AE94 /* CoreDataManager.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -284,6 +287,7 @@
 				B3FE9B3D2858890D0006A7AB /* DiaryViewController.swift in Sources */,
 				AC50348928582BDE0068C2A0 /* ListTableViewCell.swift in Sources */,
 				B32FEFA228600F5600F3A6B5 /* Model.xcdatamodeld in Sources */,
+				B3D761702860131C00C4AE94 /* CoreDataManager.swift in Sources */,
 				B3FE9B3B285853F60006A7AB /* DiaryData.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		B32FEFA52860116500F3A6B5 /* DiaryModel+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = B32FEFA32860116500F3A6B5 /* DiaryModel+CoreDataClass.swift */; };
 		B32FEFA62860116500F3A6B5 /* DiaryModel+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = B32FEFA42860116500F3A6B5 /* DiaryModel+CoreDataProperties.swift */; };
 		B3427841286192F3004488E4 /* Notification.Name+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3427840286192F3004488E4 /* Notification.Name+.swift */; };
+		B3940C7E2862BF1400EB2280 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3940C7D2862BF1400EB2280 /* UIViewController+.swift */; };
 		B3D761702860131C00C4AE94 /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D7616F2860131C00C4AE94 /* CoreDataManager.swift */; };
 		B3FB2B2B285C1EC6009A932C /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FB2B2A285C1EC6009A932C /* Date+.swift */; };
 		B3FE9B39285820680006A7AB /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FE9B38285820680006A7AB /* MainView.swift */; };
@@ -41,6 +42,7 @@
 		B32FEFA32860116500F3A6B5 /* DiaryModel+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiaryModel+CoreDataClass.swift"; sourceTree = "<group>"; };
 		B32FEFA42860116500F3A6B5 /* DiaryModel+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiaryModel+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		B3427840286192F3004488E4 /* Notification.Name+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Notification.Name+.swift"; path = "Diary/Controller/Notification.Name+.swift"; sourceTree = SOURCE_ROOT; };
+		B3940C7D2862BF1400EB2280 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIViewController+.swift"; path = "Diary/Controller/UIViewController+.swift"; sourceTree = SOURCE_ROOT; };
 		B3D7616F2860131C00C4AE94 /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
 		B3FB2B2A285C1EC6009A932C /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		B3FE9B38285820680006A7AB /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
@@ -80,6 +82,7 @@
 		AC50348A28582C050068C2A0 /* Extension */ = {
 			isa = PBXGroup;
 			children = (
+				B3940C7D2862BF1400EB2280 /* UIViewController+.swift */,
 				B3427840286192F3004488E4 /* Notification.Name+.swift */,
 				AC50348B28582C450068C2A0 /* UIStackView+.swift */,
 				B3FB2B2A285C1EC6009A932C /* Date+.swift */,
@@ -278,6 +281,7 @@
 			files = (
 				AC7E277C2860028500FB90D0 /* EditViewController.swift in Sources */,
 				B3427841286192F3004488E4 /* Notification.Name+.swift in Sources */,
+				B3940C7E2862BF1400EB2280 /* UIViewController+.swift in Sources */,
 				B32FEFA52860116500F3A6B5 /* DiaryModel+CoreDataClass.swift in Sources */,
 				AC50348C28582C450068C2A0 /* UIStackView+.swift in Sources */,
 				C739AE29284DF28600741E8F /* ListViewController.swift in Sources */,

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		B32FEFA228600F5600F3A6B5 /* Model.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = B32FEFA028600F5600F3A6B5 /* Model.xcdatamodeld */; };
 		B32FEFA52860116500F3A6B5 /* DiaryModel+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = B32FEFA32860116500F3A6B5 /* DiaryModel+CoreDataClass.swift */; };
 		B32FEFA62860116500F3A6B5 /* DiaryModel+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = B32FEFA42860116500F3A6B5 /* DiaryModel+CoreDataProperties.swift */; };
+		B3427841286192F3004488E4 /* Notification.Name+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3427840286192F3004488E4 /* Notification.Name+.swift */; };
 		B3D761702860131C00C4AE94 /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D7616F2860131C00C4AE94 /* CoreDataManager.swift */; };
 		B3FB2B2B285C1EC6009A932C /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FB2B2A285C1EC6009A932C /* Date+.swift */; };
 		B3FE9B39285820680006A7AB /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FE9B38285820680006A7AB /* MainView.swift */; };
@@ -39,6 +40,7 @@
 		B32FEFA128600F5600F3A6B5 /* Model.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model.xcdatamodel; sourceTree = "<group>"; };
 		B32FEFA32860116500F3A6B5 /* DiaryModel+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiaryModel+CoreDataClass.swift"; sourceTree = "<group>"; };
 		B32FEFA42860116500F3A6B5 /* DiaryModel+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiaryModel+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		B3427840286192F3004488E4 /* Notification.Name+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Notification.Name+.swift"; path = "Diary/Controller/Notification.Name+.swift"; sourceTree = SOURCE_ROOT; };
 		B3D7616F2860131C00C4AE94 /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
 		B3FB2B2A285C1EC6009A932C /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		B3FE9B38285820680006A7AB /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
@@ -78,6 +80,7 @@
 		AC50348A28582C050068C2A0 /* Extension */ = {
 			isa = PBXGroup;
 			children = (
+				B3427840286192F3004488E4 /* Notification.Name+.swift */,
 				AC50348B28582C450068C2A0 /* UIStackView+.swift */,
 				B3FB2B2A285C1EC6009A932C /* Date+.swift */,
 			);
@@ -274,6 +277,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AC7E277C2860028500FB90D0 /* EditViewController.swift in Sources */,
+				B3427841286192F3004488E4 /* Notification.Name+.swift in Sources */,
 				B32FEFA52860116500F3A6B5 /* DiaryModel+CoreDataClass.swift in Sources */,
 				AC50348C28582C450068C2A0 /* UIStackView+.swift in Sources */,
 				C739AE29284DF28600741E8F /* ListViewController.swift in Sources */,

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -13,6 +13,9 @@
 		AC7E277A2860027E00FB90D0 /* AddViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC7E27792860027E00FB90D0 /* AddViewController.swift */; };
 		AC7E277C2860028500FB90D0 /* EditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC7E277B2860028500FB90D0 /* EditViewController.swift */; };
 		ACFA965628596909009DFD8F /* DiaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACFA965528596909009DFD8F /* DiaryView.swift */; };
+		B32FEFA228600F5600F3A6B5 /* Model.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = B32FEFA028600F5600F3A6B5 /* Model.xcdatamodeld */; };
+		B32FEFA52860116500F3A6B5 /* DiaryModel+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = B32FEFA32860116500F3A6B5 /* DiaryModel+CoreDataClass.swift */; };
+		B32FEFA62860116500F3A6B5 /* DiaryModel+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = B32FEFA42860116500F3A6B5 /* DiaryModel+CoreDataProperties.swift */; };
 		B3FB2B2B285C1EC6009A932C /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FB2B2A285C1EC6009A932C /* Date+.swift */; };
 		B3FE9B39285820680006A7AB /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FE9B38285820680006A7AB /* MainView.swift */; };
 		B3FE9B3B285853F60006A7AB /* DiaryData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FE9B3A285853F60006A7AB /* DiaryData.swift */; };
@@ -20,7 +23,6 @@
 		C739AE25284DF28600741E8F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C739AE24284DF28600741E8F /* AppDelegate.swift */; };
 		C739AE27284DF28600741E8F /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C739AE26284DF28600741E8F /* SceneDelegate.swift */; };
 		C739AE29284DF28600741E8F /* ListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C739AE28284DF28600741E8F /* ListViewController.swift */; };
-		C739AE2F284DF28600741E8F /* Diary.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = C739AE2D284DF28600741E8F /* Diary.xcdatamodeld */; };
 		C739AE31284DF28600741E8F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C739AE30284DF28600741E8F /* Assets.xcassets */; };
 		C739AE34284DF28600741E8F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C739AE32284DF28600741E8F /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
@@ -33,6 +35,9 @@
 		AC7E27792860027E00FB90D0 /* AddViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddViewController.swift; sourceTree = "<group>"; };
 		AC7E277B2860028500FB90D0 /* EditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditViewController.swift; sourceTree = "<group>"; };
 		ACFA965528596909009DFD8F /* DiaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryView.swift; sourceTree = "<group>"; };
+		B32FEFA128600F5600F3A6B5 /* Model.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model.xcdatamodel; sourceTree = "<group>"; };
+		B32FEFA32860116500F3A6B5 /* DiaryModel+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiaryModel+CoreDataClass.swift"; sourceTree = "<group>"; };
+		B32FEFA42860116500F3A6B5 /* DiaryModel+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiaryModel+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		B3FB2B2A285C1EC6009A932C /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		B3FE9B38285820680006A7AB /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
 		B3FE9B3A285853F60006A7AB /* DiaryData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryData.swift; sourceTree = "<group>"; };
@@ -41,7 +46,6 @@
 		C739AE24284DF28600741E8F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C739AE26284DF28600741E8F /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		C739AE28284DF28600741E8F /* ListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListViewController.swift; sourceTree = "<group>"; };
-		C739AE2E284DF28600741E8F /* Diary.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Diary.xcdatamodel; sourceTree = "<group>"; };
 		C739AE30284DF28600741E8F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C739AE33284DF28600741E8F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C739AE35284DF28600741E8F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -110,6 +114,8 @@
 		C739AE18284DF28600741E8F = {
 			isa = PBXGroup;
 			children = (
+				B32FEFA32860116500F3A6B5 /* DiaryModel+CoreDataClass.swift */,
+				B32FEFA42860116500F3A6B5 /* DiaryModel+CoreDataProperties.swift */,
 				C739AE23284DF28600741E8F /* Diary */,
 				C739AE22284DF28600741E8F /* Products */,
 				66692EE6C238CE0BA38B6037 /* Pods */,
@@ -137,7 +143,7 @@
 				C739AE24284DF28600741E8F /* AppDelegate.swift */,
 				C739AE26284DF28600741E8F /* SceneDelegate.swift */,
 				C739AE35284DF28600741E8F /* Info.plist */,
-				C739AE2D284DF28600741E8F /* Diary.xcdatamodeld */,
+				B32FEFA028600F5600F3A6B5 /* Model.xcdatamodeld */,
 			);
 			path = Diary;
 			sourceTree = "<group>";
@@ -265,17 +271,19 @@
 			buildActionMask = 2147483647;
 			files = (
 				AC7E277C2860028500FB90D0 /* EditViewController.swift in Sources */,
+				B32FEFA52860116500F3A6B5 /* DiaryModel+CoreDataClass.swift in Sources */,
 				AC50348C28582C450068C2A0 /* UIStackView+.swift in Sources */,
 				C739AE29284DF28600741E8F /* ListViewController.swift in Sources */,
 				AC7E277A2860027E00FB90D0 /* AddViewController.swift in Sources */,
 				B3FB2B2B285C1EC6009A932C /* Date+.swift in Sources */,
 				C739AE25284DF28600741E8F /* AppDelegate.swift in Sources */,
 				C739AE27284DF28600741E8F /* SceneDelegate.swift in Sources */,
+				B32FEFA62860116500F3A6B5 /* DiaryModel+CoreDataProperties.swift in Sources */,
 				ACFA965628596909009DFD8F /* DiaryView.swift in Sources */,
 				B3FE9B39285820680006A7AB /* MainView.swift in Sources */,
 				B3FE9B3D2858890D0006A7AB /* DiaryViewController.swift in Sources */,
-				C739AE2F284DF28600741E8F /* Diary.xcdatamodeld in Sources */,
 				AC50348928582BDE0068C2A0 /* ListTableViewCell.swift in Sources */,
+				B32FEFA228600F5600F3A6B5 /* Model.xcdatamodeld in Sources */,
 				B3FE9B3B285853F60006A7AB /* DiaryData.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -492,13 +500,13 @@
 /* End XCConfigurationList section */
 
 /* Begin XCVersionGroup section */
-		C739AE2D284DF28600741E8F /* Diary.xcdatamodeld */ = {
+		B32FEFA028600F5600F3A6B5 /* Model.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
-				C739AE2E284DF28600741E8F /* Diary.xcdatamodel */,
+				B32FEFA128600F5600F3A6B5 /* Model.xcdatamodel */,
 			);
-			currentVersion = C739AE2E284DF28600741E8F /* Diary.xcdatamodel */;
-			path = Diary.xcdatamodeld;
+			currentVersion = B32FEFA128600F5600F3A6B5 /* Model.xcdatamodel */;
+			path = Model.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;
 		};

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -21,7 +21,7 @@
 		B3D761702860131C00C4AE94 /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D7616F2860131C00C4AE94 /* CoreDataManager.swift */; };
 		B3FB2B2B285C1EC6009A932C /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FB2B2A285C1EC6009A932C /* Date+.swift */; };
 		B3FE9B39285820680006A7AB /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FE9B38285820680006A7AB /* MainView.swift */; };
-		B3FE9B3B285853F60006A7AB /* DiaryData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FE9B3A285853F60006A7AB /* DiaryData.swift */; };
+		B3FE9B3B285853F60006A7AB /* Diary.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FE9B3A285853F60006A7AB /* Diary.swift */; };
 		B3FE9B3D2858890D0006A7AB /* DiaryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FE9B3C2858890D0006A7AB /* DiaryViewController.swift */; };
 		C739AE25284DF28600741E8F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C739AE24284DF28600741E8F /* AppDelegate.swift */; };
 		C739AE27284DF28600741E8F /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C739AE26284DF28600741E8F /* SceneDelegate.swift */; };
@@ -46,7 +46,7 @@
 		B3D7616F2860131C00C4AE94 /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
 		B3FB2B2A285C1EC6009A932C /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		B3FE9B38285820680006A7AB /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
-		B3FE9B3A285853F60006A7AB /* DiaryData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryData.swift; sourceTree = "<group>"; };
+		B3FE9B3A285853F60006A7AB /* Diary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Diary.swift; sourceTree = "<group>"; };
 		B3FE9B3C2858890D0006A7AB /* DiaryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryViewController.swift; sourceTree = "<group>"; };
 		C739AE21284DF28600741E8F /* Diary.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Diary.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C739AE24284DF28600741E8F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -114,7 +114,7 @@
 		B3FE9B4028588AAA0006A7AB /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				B3FE9B3A285853F60006A7AB /* DiaryData.swift */,
+				B3FE9B3A285853F60006A7AB /* Diary.swift */,
 				B3D7616F2860131C00C4AE94 /* CoreDataManager.swift */,
 			);
 			path = Model;
@@ -296,7 +296,7 @@
 				AC50348928582BDE0068C2A0 /* ListTableViewCell.swift in Sources */,
 				B32FEFA228600F5600F3A6B5 /* Model.xcdatamodeld in Sources */,
 				B3D761702860131C00C4AE94 /* CoreDataManager.swift in Sources */,
-				B3FE9B3B285853F60006A7AB /* DiaryData.swift in Sources */,
+				B3FE9B3B285853F60006A7AB /* Diary.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Diary/AppDelegate.swift
+++ b/Diary/AppDelegate.swift
@@ -5,7 +5,6 @@
 // 
 
 import UIKit
-import CoreData
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -30,51 +29,5 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
-
-    // MARK: - Core Data stack
-
-    lazy var persistentContainer: NSPersistentContainer = {
-        /*
-         The persistent container for the application. This implementation
-         creates and returns a container, having loaded the store for the
-         application to it. This property is optional since there are legitimate
-         error conditions that could cause the creation of the store to fail.
-        */
-        let container = NSPersistentContainer(name: "Diary")
-        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
-            if let error = error as NSError? {
-                // Replace this implementation with code to handle the error appropriately.
-                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-                 
-                /*
-                 Typical reasons for an error here include:
-                 * The parent directory does not exist, cannot be created, or disallows writing.
-                 * The persistent store is not accessible, due to permissions or data protection when the device is locked.
-                 * The device is out of space.
-                 * The store could not be migrated to the current model version.
-                 Check the error message to determine what the actual problem was.
-                 */
-                fatalError("Unresolved error \(error), \(error.userInfo)")
-            }
-        })
-        return container
-    }()
-
-    // MARK: - Core Data Saving support
-
-    func saveContext () {
-        let context = persistentContainer.viewContext
-        if context.hasChanges {
-            do {
-                try context.save()
-            } catch {
-                // Replace this implementation with code to handle the error appropriately.
-                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-                let nserror = error as NSError
-                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
-            }
-        }
-    }
-
 }
 

--- a/Diary/Controller/AddViewController.swift
+++ b/Diary/Controller/AddViewController.swift
@@ -15,6 +15,12 @@ final class AddViewController: DiaryViewController {
         setInitialView()
     }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        update(setTestData())
+        delegate?.updateView()
+    }
+    
     private func setInitialView() {
         self.title = Date().dateToKoreanString
     }

--- a/Diary/Controller/AddViewController.swift
+++ b/Diary/Controller/AddViewController.swift
@@ -15,6 +15,11 @@ final class AddViewController: DiaryViewController {
         setInitialView()
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        diaryView.diaryTextView.becomeFirstResponder()
+    }
+    
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         update(setTestData())

--- a/Diary/Controller/AddViewController.swift
+++ b/Diary/Controller/AddViewController.swift
@@ -37,7 +37,7 @@ final class AddViewController: DiaryViewController {
     }
     
     private func setTestData() -> Diary? {
-        var textArray = diaryView.diaryTextView.text.components(separatedBy: "\n")
+        var textArray = diaryText()
         return Diary(title: textArray.removeFirst(), body: textArray.joined(separator: "\n"), createdAt: Date().timeIntervalSince1970, id: id)
     }
 }

--- a/Diary/Controller/AddViewController.swift
+++ b/Diary/Controller/AddViewController.swift
@@ -8,8 +8,6 @@
 import UIKit
 
 final class AddViewController: DiaryViewController {
-    let id = UUID()
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         setInitialView()
@@ -20,24 +18,7 @@ final class AddViewController: DiaryViewController {
         diaryView.diaryTextView.becomeFirstResponder()
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        saveDiary()
-    }
-    
     private func setInitialView() {
         self.title = Date().dateToKoreanString
-        NotificationCenter.default.addObserver(self, selector: #selector(saveDiary), name: Notification.Name.sceneDidEnterBackgroundNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(saveDiary), name: UIResponder.keyboardWillHideNotification, object: nil)
-    }
-    
-    @objc func saveDiary() {
-        update(setTestData())
-        delegate?.updateView()
-    }
-    
-    private func setTestData() -> Diary? {
-        var textArray = diaryText()
-        return Diary(title: textArray.removeFirst(), body: textArray.joined(separator: "\n"), createdAt: Date().timeIntervalSince1970, id: id)
     }
 }

--- a/Diary/Controller/AddViewController.swift
+++ b/Diary/Controller/AddViewController.swift
@@ -28,6 +28,8 @@ final class AddViewController: DiaryViewController {
     private func setInitialView() {
         self.title = Date().dateToKoreanString
         NotificationCenter.default.addObserver(self, selector: #selector(saveDiary), name: Notification.Name.sceneDidEnterBackgroundNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(saveDiary), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
     
     @objc func saveDiary() {
         update(setTestData())

--- a/Diary/Controller/AddViewController.swift
+++ b/Diary/Controller/AddViewController.swift
@@ -8,7 +8,8 @@
 import UIKit
 
 final class AddViewController: DiaryViewController {
-
+    let id = UUID()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setInitialView()
@@ -16,5 +17,10 @@ final class AddViewController: DiaryViewController {
     
     private func setInitialView() {
         self.title = Date().dateToKoreanString
+    }
+    
+    private func setTestData() -> TestData? {
+        var textArray = diaryView.diaryTextView.text.components(separatedBy: "\n")
+        return TestData(title: textArray.removeFirst(), body: textArray.joined(separator: "\n"), createdAt: Date().timeIntervalSince1970, id: id)
     }
 }

--- a/Diary/Controller/AddViewController.swift
+++ b/Diary/Controller/AddViewController.swift
@@ -25,8 +25,8 @@ final class AddViewController: DiaryViewController {
         self.title = Date().dateToKoreanString
     }
     
-    private func setTestData() -> TestData? {
+    private func setTestData() -> Diary? {
         var textArray = diaryView.diaryTextView.text.components(separatedBy: "\n")
-        return TestData(title: textArray.removeFirst(), body: textArray.joined(separator: "\n"), createdAt: Date().timeIntervalSince1970, id: id)
+        return Diary(title: textArray.removeFirst(), body: textArray.joined(separator: "\n"), createdAt: Date().timeIntervalSince1970, id: id)
     }
 }

--- a/Diary/Controller/AddViewController.swift
+++ b/Diary/Controller/AddViewController.swift
@@ -22,12 +22,16 @@ final class AddViewController: DiaryViewController {
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        update(setTestData())
-        delegate?.updateView()
+        saveDiary()
     }
     
     private func setInitialView() {
         self.title = Date().dateToKoreanString
+        NotificationCenter.default.addObserver(self, selector: #selector(saveDiary), name: Notification.Name.sceneDidEnterBackgroundNotification, object: nil)
+    
+    @objc func saveDiary() {
+        update(setTestData())
+        delegate?.updateView()
     }
     
     private func setTestData() -> Diary? {

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -30,5 +30,15 @@ class DiaryViewController: UIViewController {
     
     private func setInitialView() {
         self.view = diaryView
+        self.navigationItem.setRightBarButton(optionButton(), animated: true)
+    }
+    
+    private func optionButton() -> UIBarButtonItem {
+        let barButton = UIBarButtonItem(image: UIImage(systemName: "ellipsis.circle"), style: .plain, target: self, action: #selector(showMenu))
+        
+        return barButton
+    }
+    
+    @objc private func showMenu() {
     }
 }

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -21,7 +21,22 @@ class DiaryViewController: UIViewController {
         self.view = diaryView
         NotificationCenter.default.addObserver(self, selector: #selector(saveDiary), name: Notification.Name.sceneDidEnterBackgroundNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(saveDiary), name: UIResponder.keyboardWillHideNotification, object: nil)
+        configureBackButton()
         configureOptionButton()
+    }
+    
+    private func configureBackButton() {
+        let button = UIButton()
+        button.setImage(UIImage(systemName: "chevron.left"), for: .normal)
+        button.frame = CGRect(x: 0, y: 0, width: 80, height: 30)
+        button.setTitle(" 일기장", for: .normal)
+        button.setTitleColor(.systemBlue, for: .normal)
+        button.addTarget(self, action: #selector(touchBackButton), for: .touchUpInside)
+        button.contentHorizontalAlignment = .leading
+        
+        let barButton = UIBarButtonItem(customView: button)
+        
+        self.navigationItem.setLeftBarButton(barButton, animated: true)
     }
     
     private func configureOptionButton() {
@@ -74,6 +89,11 @@ class DiaryViewController: UIViewController {
         alert.addAction(deleteAction)
         
         self.present(alert, animated: true)
+    }
+    
+    @objc private func touchBackButton() {
+        saveDiary()
+        navigationController?.popViewController(animated: true)
     }
     
     @objc private func touchOptionButton() {

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 class DiaryViewController: UIViewController {
     lazy var diaryView = DiaryView.init(frame: view.bounds)
+    weak var delegate: DataSendable?
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -17,7 +17,12 @@ class DiaryViewController: UIViewController {
         setInitialView()
     }
     
-    func update(_ testData: Diary?) {
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        saveDiary()
+    }
+    
+    private func update(_ testData: Diary?) {
         do {
             guard let testData = testData else {
                 return
@@ -29,7 +34,7 @@ class DiaryViewController: UIViewController {
         }
     }
     
-    func diaryText() -> [String] {
+    private func diaryText() -> [String] {
         let textArray = diaryView.diaryTextView.text.components(separatedBy: "\n")
         return textArray
     }
@@ -41,11 +46,11 @@ class DiaryViewController: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(saveDiary), name: UIResponder.keyboardWillHideNotification, object: nil)
     }
     
-    @objc func saveDiary() {
+    @objc private func saveDiary() {
+        var textArray = diaryText()
         if diary == nil {
-            
+            diary = Diary(title: textArray.removeFirst(), body: textArray.joined(separator: "\n"), createdAt: Date().timeIntervalSince1970, id: UUID())
         } else {
-            var textArray = diaryText()
             diary?.title = textArray.removeFirst()
             diary?.body = textArray.joined(separator: "\n")
         }

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 class DiaryViewController: UIViewController {
     lazy var diaryView = DiaryView.init(frame: view.bounds)
     weak var delegate: DataSendable?
+    var diary: Diary?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -36,6 +37,20 @@ class DiaryViewController: UIViewController {
     private func setInitialView() {
         self.view = diaryView
         self.navigationItem.setRightBarButton(optionButton(), animated: true)
+        NotificationCenter.default.addObserver(self, selector: #selector(saveDiary), name: Notification.Name.sceneDidEnterBackgroundNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(saveDiary), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    @objc func saveDiary() {
+        if diary == nil {
+            
+        } else {
+            var textArray = diaryText()
+            diary?.title = textArray.removeFirst()
+            diary?.body = textArray.joined(separator: "\n")
+        }
+        update(diary)
+        delegate?.updateView()
     }
     
     private func optionButton() -> UIBarButtonItem {

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -28,13 +28,18 @@ class DiaryViewController: UIViewController {
         }
     }
     
+    func diaryText() -> [String] {
+        let textArray = diaryView.diaryTextView.text.components(separatedBy: "\n")
+        return textArray
+    }
+    
     private func setInitialView() {
         self.view = diaryView
         self.navigationItem.setRightBarButton(optionButton(), animated: true)
     }
     
     private func optionButton() -> UIBarButtonItem {
-        let barButton = UIBarButtonItem(image: UIImage(systemName: "ellipsis.circle"), style: .plain, target: self, action: #selector(showMenu))
+        let barButton = UIBarButtonItem(image: UIImage(systemName: "ellipsis.circle"), style: .plain, target: self, action: #selector(touchOptionButton))
         
         return barButton
     }
@@ -42,7 +47,7 @@ class DiaryViewController: UIViewController {
     @objc private func touchOptionButton() {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         let shareAction = UIAlertAction(title: "Share...", style: .default) { _ in
-            print("공유하기")
+            self.touchShareButton()
         }
         let deleteAction = UIAlertAction(title: "Delete", style: .destructive) { _ in
             print("삭제하기")
@@ -54,5 +59,11 @@ class DiaryViewController: UIViewController {
         alert.addAction(cancelAction)
         
         self.present(alert, animated: true)
+    }
+    
+    private func touchShareButton() {
+        let text = [diaryText().joined(separator: "\n")]
+        let share = UIActivityViewController(activityItems: text, applicationActivities: nil)
+        self.present(share, animated: true)
     }
 }

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -59,7 +59,7 @@ class DiaryViewController: UIViewController {
         let textArray = diaryView.diaryTextView.text.components(separatedBy: "\n")
         var removedSpaceArray: [String] = textArray.compactMap {
             if !$0.trimmingCharacters(in: .whitespaces).isEmpty {
-                return $0
+                return $0.trimmingCharacters(in: .whitespaces)
             }
             return nil
         }

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -50,7 +50,7 @@ class DiaryViewController: UIViewController {
             self.touchShareButton()
         }
         let deleteAction = UIAlertAction(title: "Delete", style: .destructive) { _ in
-            print("삭제하기")
+            self.touchDeleteButton()
         }
         let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
 
@@ -65,5 +65,18 @@ class DiaryViewController: UIViewController {
         let text = [diaryText().joined(separator: "\n")]
         let share = UIActivityViewController(activityItems: text, applicationActivities: nil)
         self.present(share, animated: true)
+    }
+    
+    private func touchDeleteButton() {
+        let alert = UIAlertController(title: "진짜요?", message: "정말로 삭제하시겠어요?", preferredStyle: .alert)
+        let cancelAction = UIAlertAction(title: "취소", style: .default)
+        let deleteAction = UIAlertAction(title: "삭제", style: .destructive) { _ in
+            print("Delete")
+        }
+        
+        alert.addAction(cancelAction)
+        alert.addAction(deleteAction)
+        
+        self.present(alert, animated: true)
     }
 }

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -7,9 +7,13 @@
 
 import UIKit
 
+protocol DiaryViewControllerDelegate: AnyObject {
+    func updateView()
+}
+
 class DiaryViewController: UIViewController {
     lazy var diaryView = DiaryView.init(frame: view.bounds)
-    weak var delegate: DataSendable?
+    weak var delegate: DiaryViewControllerDelegate?
     var diary: Diary?
     
     override func viewDidLoad() {
@@ -19,24 +23,33 @@ class DiaryViewController: UIViewController {
     
     private func setInitialView() {
         self.view = diaryView
-        NotificationCenter.default.addObserver(self, selector: #selector(saveDiary), name: Notification.Name.sceneDidEnterBackgroundNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(saveDiary), name: UIResponder.keyboardWillHideNotification, object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(saveDiary),
+                                               name: Notification.Name.sceneDidEnterBackgroundNotification,
+                                               object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(saveDiary),
+                                               name: UIResponder.keyboardWillHideNotification,
+                                               object: nil)
         configureOptionButton()
     }
     
     private func configureOptionButton() {
-        let barButton = UIBarButtonItem(image: UIImage(systemName: "ellipsis.circle"), style: .plain, target: self, action: #selector(touchOptionButton))
+        let barButton = UIBarButtonItem(image: UIImage(systemName: "ellipsis.circle"),
+                                        style: .plain,
+                                        target: self,
+                                        action: #selector(touchOptionButton))
         
         self.navigationItem.setRightBarButton(barButton, animated: true)
     }
     
-    private func update(_ testData: Diary?) {
+    private func update(_ diaryData: Diary?) {
         do {
-            guard let testData = testData else {
+            guard let diaryData = diaryData else {
                 return
             }
 
-            try CoreDataManager.shared.update(testData)
+            try CoreDataManager.shared.update(diaryData)
         } catch {
             showErrorAlert("업데이트에 실패했습니다")
         }

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -22,6 +22,19 @@ class DiaryViewController: UIViewController {
         saveDiary()
     }
     
+    private func setInitialView() {
+        self.view = diaryView
+        NotificationCenter.default.addObserver(self, selector: #selector(saveDiary), name: Notification.Name.sceneDidEnterBackgroundNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(saveDiary), name: UIResponder.keyboardWillHideNotification, object: nil)
+        configureOptionButton()
+    }
+    
+    private func configureOptionButton() {
+        let barButton = UIBarButtonItem(image: UIImage(systemName: "ellipsis.circle"), style: .plain, target: self, action: #selector(touchOptionButton))
+        
+        self.navigationItem.setRightBarButton(barButton, animated: true)
+    }
+    
     private func update(_ testData: Diary?) {
         do {
             guard let testData = testData else {
@@ -37,48 +50,6 @@ class DiaryViewController: UIViewController {
     private func diaryText() -> [String] {
         let textArray = diaryView.diaryTextView.text.components(separatedBy: "\n")
         return textArray
-    }
-    
-    private func setInitialView() {
-        self.view = diaryView
-        self.navigationItem.setRightBarButton(optionButton(), animated: true)
-        NotificationCenter.default.addObserver(self, selector: #selector(saveDiary), name: Notification.Name.sceneDidEnterBackgroundNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(saveDiary), name: UIResponder.keyboardWillHideNotification, object: nil)
-    }
-    
-    @objc private func saveDiary() {
-        var textArray = diaryText()
-        if diary == nil {
-            diary = Diary(title: textArray.removeFirst(), body: textArray.joined(separator: "\n"), createdAt: Date().timeIntervalSince1970, id: UUID())
-        } else {
-            diary?.title = textArray.removeFirst()
-            diary?.body = textArray.joined(separator: "\n")
-        }
-        update(diary)
-        delegate?.updateView()
-    }
-    
-    private func optionButton() -> UIBarButtonItem {
-        let barButton = UIBarButtonItem(image: UIImage(systemName: "ellipsis.circle"), style: .plain, target: self, action: #selector(touchOptionButton))
-        
-        return barButton
-    }
-    
-    @objc private func touchOptionButton() {
-        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        let shareAction = UIAlertAction(title: "Share...", style: .default) { _ in
-            self.touchShareButton()
-        }
-        let deleteAction = UIAlertAction(title: "Delete", style: .destructive) { _ in
-            self.touchDeleteButton()
-        }
-        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
-
-        alert.addAction(shareAction)
-        alert.addAction(deleteAction)
-        alert.addAction(cancelAction)
-        
-        self.present(alert, animated: true)
     }
     
     private func touchShareButton() {
@@ -98,5 +69,34 @@ class DiaryViewController: UIViewController {
         alert.addAction(deleteAction)
         
         self.present(alert, animated: true)
+    }
+    
+    @objc private func touchOptionButton() {
+        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        let shareAction = UIAlertAction(title: "Share...", style: .default) { _ in
+            self.touchShareButton()
+        }
+        let deleteAction = UIAlertAction(title: "Delete", style: .destructive) { _ in
+            self.touchDeleteButton()
+        }
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
+
+        alert.addAction(shareAction)
+        alert.addAction(deleteAction)
+        alert.addAction(cancelAction)
+        
+        self.present(alert, animated: true)
+    }
+    
+    @objc private func saveDiary() {
+        var textArray = diaryText()
+        if diary == nil {
+            diary = Diary(title: textArray.removeFirst(), body: textArray.joined(separator: "\n"), createdAt: Date().timeIntervalSince1970, id: UUID())
+        } else {
+            diary?.title = textArray.removeFirst()
+            diary?.body = textArray.joined(separator: "\n")
+        }
+        update(diary)
+        delegate?.updateView()
     }
 }

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -15,6 +15,24 @@ class DiaryViewController: UIViewController {
         setInitialView()
     }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        update()
+    }
+    
+    private func update() {
+        do {
+            try CoreDataManager.shared.update(setTestData())
+        } catch {
+            print("저장에 실패했습니다")
+        }
+    }
+    
+    private func setTestData() -> TestData {
+        var textArray = diaryView.diaryTextView.text.components(separatedBy: "\n")
+        return TestData(title: textArray.removeFirst(), body: textArray.joined(separator: "\n"), createdAt: Date().timeIntervalSince1970, id: UUID())
+    }
+    
     private func setInitialView() {
         self.view = diaryView
     }

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -16,14 +16,13 @@ class DiaryViewController: UIViewController {
         setInitialView()
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        update()
-    }
-    
-    private func update() {
+    func update(_ testData: TestData?) {
         do {
-            try CoreDataManager.shared.update(setTestData())
+            guard let testData = testData else {
+                return
+            }
+
+            try CoreDataManager.shared.update(testData)
         } catch {
             print("저장에 실패했습니다")
         }

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -39,6 +39,20 @@ class DiaryViewController: UIViewController {
         return barButton
     }
     
-    @objc private func showMenu() {
+    @objc private func touchOptionButton() {
+        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        let shareAction = UIAlertAction(title: "Share...", style: .default) { _ in
+            print("공유하기")
+        }
+        let deleteAction = UIAlertAction(title: "Delete", style: .destructive) { _ in
+            print("삭제하기")
+        }
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
+
+        alert.addAction(shareAction)
+        alert.addAction(deleteAction)
+        alert.addAction(cancelAction)
+        
+        self.present(alert, animated: true)
     }
 }

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -77,6 +77,7 @@ class DiaryViewController: UIViewController {
     }
     
     @objc private func touchOptionButton() {
+        diaryView.diaryTextView.endEditing(true)
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         let shareAction = UIAlertAction(title: "Share...", style: .default) { _ in
             self.touchShareButton()

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -16,7 +16,7 @@ class DiaryViewController: UIViewController {
         setInitialView()
     }
     
-    func update(_ testData: TestData?) {
+    func update(_ testData: Diary?) {
         do {
             guard let testData = testData else {
                 return

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -38,7 +38,7 @@ class DiaryViewController: UIViewController {
 
             try CoreDataManager.shared.update(testData)
         } catch {
-            print("저장에 실패했습니다")
+            showErrorAlert("업데이트에 실패했습니다")
         }
     }
     
@@ -83,7 +83,7 @@ class DiaryViewController: UIViewController {
                 self.delegate?.updateView()
                 self.navigationController?.popViewController(animated: true)
             } catch {
-                print("삭제에 실패했습니다")
+                self.showErrorAlert("삭제에 실패했습니다")
             }
         }
         

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -42,14 +42,31 @@ class DiaryViewController: UIViewController {
         }
     }
     
-    private func diaryText() -> [String] {
+    private func setDiary() {
         let textArray = diaryView.diaryTextView.text.components(separatedBy: "\n")
-        return textArray
+        var removedSpaceArray: [String] = textArray.compactMap {
+            if !$0.trimmingCharacters(in: .whitespaces).isEmpty {
+                return $0
+            }
+            return nil
+        }
+        
+        if diary == nil {
+            diary = Diary(title: removedSpaceArray.isEmpty ? "새로운 일기" : removedSpaceArray.removeFirst(),
+                          body: removedSpaceArray.isEmpty ? "본문 없음" : removedSpaceArray[0],
+                          text: diaryView.diaryTextView.text ?? "",
+                          createdAt: Date().timeIntervalSince1970,
+                          id: UUID())
+        } else {
+            diary?.title = removedSpaceArray.isEmpty ? "새로운 일기" : removedSpaceArray.removeFirst()
+            diary?.body = removedSpaceArray.isEmpty ? "본문 없음" : removedSpaceArray[0]
+            diary?.text = diaryView.diaryTextView.text ?? ""
+        }
     }
     
     private func touchShareButton() {
-        let text = [diaryText().joined(separator: "\n")]
-        let share = UIActivityViewController(activityItems: text, applicationActivities: nil)
+        let text = diaryView.diaryTextView.text ?? ""
+        let share = UIActivityViewController(activityItems: [text], applicationActivities: nil)
         self.present(share, animated: true)
     }
     
@@ -95,13 +112,7 @@ class DiaryViewController: UIViewController {
     }
     
     @objc private func saveDiary() {
-        var textArray = diaryText()
-        if diary == nil {
-            diary = Diary(title: textArray.removeFirst(), body: textArray.joined(separator: "\n"), createdAt: Date().timeIntervalSince1970, id: UUID())
-        } else {
-            diary?.title = textArray.removeFirst()
-            diary?.body = textArray.joined(separator: "\n")
-        }
+        setDiary()
         update(diary)
         delegate?.updateView()
     }

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -57,7 +57,7 @@ class DiaryViewController: UIViewController {
     
     private func setDiary() {
         let textArray = diaryView.diaryTextView.text.components(separatedBy: "\n")
-        var removedSpaceArray: [String] = textArray.compactMap {
+        var convertedTextArray: [String] = textArray.compactMap {
             if !$0.trimmingCharacters(in: .whitespaces).isEmpty {
                 return $0.trimmingCharacters(in: .whitespaces)
             }
@@ -65,14 +65,14 @@ class DiaryViewController: UIViewController {
         }
         
         if diary == nil {
-            diary = Diary(title: removedSpaceArray.isEmpty ? "새로운 일기" : removedSpaceArray.removeFirst(),
-                          body: removedSpaceArray.isEmpty ? "본문 없음" : removedSpaceArray[0],
+            diary = Diary(title: convertedTextArray.isEmpty ? "새로운 일기" : convertedTextArray.removeFirst(),
+                          body: convertedTextArray.isEmpty ? "본문 없음" : convertedTextArray[0],
                           text: diaryView.diaryTextView.text ?? "",
                           createdAt: Date().timeIntervalSince1970,
                           id: UUID())
         } else {
-            diary?.title = removedSpaceArray.isEmpty ? "새로운 일기" : removedSpaceArray.removeFirst()
-            diary?.body = removedSpaceArray.isEmpty ? "본문 없음" : removedSpaceArray[0]
+            diary?.title = convertedTextArray.isEmpty ? "새로운 일기" : convertedTextArray.removeFirst()
+            diary?.body = convertedTextArray.isEmpty ? "본문 없음" : convertedTextArray[0]
             diary?.text = diaryView.diaryTextView.text ?? ""
         }
     }

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -17,11 +17,6 @@ class DiaryViewController: UIViewController {
         setInitialView()
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        saveDiary()
-    }
-    
     private func setInitialView() {
         self.view = diaryView
         NotificationCenter.default.addObserver(self, selector: #selector(saveDiary), name: Notification.Name.sceneDidEnterBackgroundNotification, object: nil)
@@ -62,7 +57,17 @@ class DiaryViewController: UIViewController {
         let alert = UIAlertController(title: "진짜요?", message: "정말로 삭제하시겠어요?", preferredStyle: .alert)
         let cancelAction = UIAlertAction(title: "취소", style: .default)
         let deleteAction = UIAlertAction(title: "삭제", style: .destructive) { _ in
-            print("Delete")
+            guard let diary = self.diary else {
+                return
+            }
+            
+            do {
+                try CoreDataManager.shared.delete(diary)
+                self.delegate?.updateView()
+                self.navigationController?.popViewController(animated: true)
+            } catch {
+                print("삭제에 실패했습니다")
+            }
         }
         
         alert.addAction(cancelAction)

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -21,22 +21,7 @@ class DiaryViewController: UIViewController {
         self.view = diaryView
         NotificationCenter.default.addObserver(self, selector: #selector(saveDiary), name: Notification.Name.sceneDidEnterBackgroundNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(saveDiary), name: UIResponder.keyboardWillHideNotification, object: nil)
-        configureBackButton()
         configureOptionButton()
-    }
-    
-    private func configureBackButton() {
-        let button = UIButton()
-        button.setImage(UIImage(systemName: "chevron.left"), for: .normal)
-        button.frame = CGRect(x: 0, y: 0, width: 80, height: 30)
-        button.setTitle(" 일기장", for: .normal)
-        button.setTitleColor(.systemBlue, for: .normal)
-        button.addTarget(self, action: #selector(touchBackButton), for: .touchUpInside)
-        button.contentHorizontalAlignment = .leading
-        
-        let barButton = UIBarButtonItem(customView: button)
-        
-        self.navigationItem.setLeftBarButton(barButton, animated: true)
     }
     
     private func configureOptionButton() {
@@ -89,11 +74,6 @@ class DiaryViewController: UIViewController {
         alert.addAction(deleteAction)
         
         self.present(alert, animated: true)
-    }
-    
-    @objc private func touchBackButton() {
-        saveDiary()
-        navigationController?.popViewController(animated: true)
     }
     
     @objc private func touchOptionButton() {

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -29,11 +29,6 @@ class DiaryViewController: UIViewController {
         }
     }
     
-    private func setTestData() -> TestData {
-        var textArray = diaryView.diaryTextView.text.components(separatedBy: "\n")
-        return TestData(title: textArray.removeFirst(), body: textArray.joined(separator: "\n"), createdAt: Date().timeIntervalSince1970, id: UUID())
-    }
-    
     private func setInitialView() {
         self.view = diaryView
     }

--- a/Diary/Controller/EditViewController.swift
+++ b/Diary/Controller/EditViewController.swift
@@ -8,9 +8,9 @@
 import UIKit
 
 final class EditViewController: DiaryViewController {
-    private var diary: Diary?
+    private var diary: DiaryModel?
     
-    init(diary: Diary?) {
+    init(diary: DiaryModel?) {
         self.diary = diary
         super.init(nibName: nil, bundle: nil)
     }

--- a/Diary/Controller/EditViewController.swift
+++ b/Diary/Controller/EditViewController.swift
@@ -26,8 +26,7 @@ final class EditViewController: DiaryViewController {
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        update(setTestData())
-        delegate?.updateView()
+        saveDiary()
     }
     
     private func setInitialView() {
@@ -35,6 +34,11 @@ final class EditViewController: DiaryViewController {
             self.title = Date(timeIntervalSince1970: createdAt).dateToKoreanString
             configureDiaryView()
         }
+        NotificationCenter.default.addObserver(self, selector: #selector(saveDiary), name: Notification.Name.sceneDidEnterBackgroundNotification, object: nil)
+    
+    @objc func saveDiary() {
+        update(setTestData())
+        delegate?.updateView()
     }
     
     private func setTestData() -> Diary? {

--- a/Diary/Controller/EditViewController.swift
+++ b/Diary/Controller/EditViewController.swift
@@ -27,6 +27,12 @@ final class EditViewController: DiaryViewController {
     private func setInitialView() {
         self.title = diary?.createdAt ?? ""
         configureDiaryView()
+    private func setTestData() -> TestData? {
+        var textArray = diaryView.diaryTextView.text.components(separatedBy: "\n")
+        guard let id = diary?.id else {
+            return nil
+        }
+        return TestData(title: textArray.removeFirst(), body: textArray.joined(separator: "\n"), createdAt: Date().timeIntervalSince1970, id: id)
     }
     
     private func configureDiaryView() {

--- a/Diary/Controller/EditViewController.swift
+++ b/Diary/Controller/EditViewController.swift
@@ -21,12 +21,7 @@ final class EditViewController: DiaryViewController {
         super.viewDidLoad()
         setInitialView()
     }
-    
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        saveDiary()
-    }
-    
+
     private func setInitialView() {
         if let createdAt = diary?.createdAt {
             self.title = Date(timeIntervalSince1970: createdAt).dateToKoreanString

--- a/Diary/Controller/EditViewController.swift
+++ b/Diary/Controller/EditViewController.swift
@@ -8,9 +8,9 @@
 import UIKit
 
 final class EditViewController: DiaryViewController {
-    private var diary: DiaryModel?
+    private var diary: Diary?
     
-    init(diary: DiaryModel?) {
+    init(diary: Diary?) {
         super.init(nibName: nil, bundle: nil)
         self.diary = diary
     }

--- a/Diary/Controller/EditViewController.swift
+++ b/Diary/Controller/EditViewController.swift
@@ -24,6 +24,12 @@ final class EditViewController: DiaryViewController {
         setInitialView()
     }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        update(setTestData())
+        delegate?.updateView()
+    }
+    
     private func setInitialView() {
         self.title = diary?.createdAt ?? ""
         configureDiaryView()

--- a/Diary/Controller/EditViewController.swift
+++ b/Diary/Controller/EditViewController.swift
@@ -8,8 +8,6 @@
 import UIKit
 
 final class EditViewController: DiaryViewController {
-    private var diary: Diary?
-    
     init(diary: Diary?) {
         super.init(nibName: nil, bundle: nil)
         self.diary = diary
@@ -34,24 +32,8 @@ final class EditViewController: DiaryViewController {
             self.title = Date(timeIntervalSince1970: createdAt).dateToKoreanString
             configureDiaryView()
         }
-        
-        NotificationCenter.default.addObserver(self, selector: #selector(saveDiary), name: Notification.Name.sceneDidEnterBackgroundNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(saveDiary), name: UIResponder.keyboardWillHideNotification, object: nil)
     }
-    
-    @objc func saveDiary() {
-        update(setTestData())
-        delegate?.updateView()
-    }
-    
-    private func setTestData() -> Diary? {
-        var textArray = diaryText()
-        guard let id = diary?.id else {
-            return nil
-        }
-        return Diary(title: textArray.removeFirst(), body: textArray.joined(separator: "\n"), createdAt: Date().timeIntervalSince1970, id: id)
-    }
-    
+
     private func configureDiaryView() {
         guard let diary = diary else {
             return

--- a/Diary/Controller/EditViewController.swift
+++ b/Diary/Controller/EditViewController.swift
@@ -37,12 +37,12 @@ final class EditViewController: DiaryViewController {
         }
     }
     
-    private func setTestData() -> TestData? {
+    private func setTestData() -> Diary? {
         var textArray = diaryView.diaryTextView.text.components(separatedBy: "\n")
         guard let id = diary?.id else {
             return nil
         }
-        return TestData(title: textArray.removeFirst(), body: textArray.joined(separator: "\n"), createdAt: Date().timeIntervalSince1970, id: id)
+        return Diary(title: textArray.removeFirst(), body: textArray.joined(separator: "\n"), createdAt: Date().timeIntervalSince1970, id: id)
     }
     
     private func configureDiaryView() {

--- a/Diary/Controller/EditViewController.swift
+++ b/Diary/Controller/EditViewController.swift
@@ -45,7 +45,7 @@ final class EditViewController: DiaryViewController {
     }
     
     private func setTestData() -> Diary? {
-        var textArray = diaryView.diaryTextView.text.components(separatedBy: "\n")
+        var textArray = diaryText()
         guard let id = diary?.id else {
             return nil
         }

--- a/Diary/Controller/EditViewController.swift
+++ b/Diary/Controller/EditViewController.swift
@@ -11,8 +11,8 @@ final class EditViewController: DiaryViewController {
     private var diary: DiaryModel?
     
     init(diary: DiaryModel?) {
-        self.diary = diary
         super.init(nibName: nil, bundle: nil)
+        self.diary = diary
     }
     
     required init?(coder: NSCoder) {

--- a/Diary/Controller/EditViewController.swift
+++ b/Diary/Controller/EditViewController.swift
@@ -31,8 +31,12 @@ final class EditViewController: DiaryViewController {
     }
     
     private func setInitialView() {
-        self.title = diary?.createdAt ?? ""
-        configureDiaryView()
+        if let createdAt = diary?.createdAt {
+            self.title = Date(timeIntervalSince1970: createdAt).dateToKoreanString
+            configureDiaryView()
+        }
+    }
+    
     private func setTestData() -> TestData? {
         var textArray = diaryView.diaryTextView.text.components(separatedBy: "\n")
         guard let id = diary?.id else {

--- a/Diary/Controller/EditViewController.swift
+++ b/Diary/Controller/EditViewController.swift
@@ -34,7 +34,10 @@ final class EditViewController: DiaryViewController {
             self.title = Date(timeIntervalSince1970: createdAt).dateToKoreanString
             configureDiaryView()
         }
+        
         NotificationCenter.default.addObserver(self, selector: #selector(saveDiary), name: Notification.Name.sceneDidEnterBackgroundNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(saveDiary), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
     
     @objc func saveDiary() {
         update(setTestData())

--- a/Diary/Controller/EditViewController.swift
+++ b/Diary/Controller/EditViewController.swift
@@ -23,10 +23,12 @@ final class EditViewController: DiaryViewController {
     }
 
     private func setInitialView() {
-        if let createdAt = diary?.createdAt {
-            self.title = Date(timeIntervalSince1970: createdAt).dateToKoreanString
-            configureDiaryView()
+        guard let createdAt = diary?.createdAt else {
+            return
         }
+        
+        self.title = Date(timeIntervalSince1970: createdAt).dateToKoreanString
+        configureDiaryView()
     }
 
     private func configureDiaryView() {

--- a/Diary/Controller/ListViewController.swift
+++ b/Diary/Controller/ListViewController.swift
@@ -48,6 +48,7 @@ final class ListViewController: UIViewController {
                              createdAt: $0.createdAt,
                              id: $0.id)
             }
+            diaryArray.reverse()
         } catch {
             print(error.localizedDescription)
         }

--- a/Diary/Controller/ListViewController.swift
+++ b/Diary/Controller/ListViewController.swift
@@ -6,6 +6,10 @@
 
 import UIKit
 
+protocol DataSendable: NSObject {
+    func updateView()
+}
+
 final class ListViewController: UIViewController {
     private lazy var mainView = MainView.init(frame: view.bounds)
     private var diaryArray: [DiaryModel] = [] {
@@ -39,6 +43,7 @@ final class ListViewController: UIViewController {
     @objc private func touchPlusButton() {
         let addViewController = AddViewController()
         
+        addViewController.delegate = self
         self.navigationController?.pushViewController(addViewController, animated: true)
     }
     
@@ -78,6 +83,17 @@ extension ListViewController: UITableViewDelegate {
         
         let editViewController = EditViewController(diary: diaryArray[indexPath.row])
         
+        editViewController.delegate = self
         self.navigationController?.pushViewController(editViewController, animated: true)
+    }
+}
+
+extension ListViewController: DataSendable {
+    func updateView() {
+        do {
+            diaryArray = try CoreDataManager.shared.read()
+        } catch {
+            print(error.localizedDescription)
+        }
     }
 }

--- a/Diary/Controller/ListViewController.swift
+++ b/Diary/Controller/ListViewController.swift
@@ -12,7 +12,7 @@ protocol DataSendable: NSObject {
 
 final class ListViewController: UIViewController {
     private lazy var mainView = MainView.init(frame: view.bounds)
-    private var diaryArray: [DiaryModel] = [] {
+    private var diaryArray: [Diary] = [] {
         didSet {
             DispatchQueue.main.async {
                 self.mainView.tableView.reloadData()
@@ -31,7 +31,7 @@ final class ListViewController: UIViewController {
         mainView.tableView.delegate = self
         mainView.tableView.register(ListTableViewCell.self, forCellReuseIdentifier: "\(ListTableViewCell.self)")
         configureNavigationBar()
-        appendDiary(diaryArray)
+        readDiaryDatas()
     }
     
     private func configureNavigationBar() {
@@ -47,10 +47,14 @@ final class ListViewController: UIViewController {
         self.navigationController?.pushViewController(addViewController, animated: true)
     }
     
-    private func appendDiary(_ data: [DiaryModel]?) {
+    private func readDiaryDatas() {
         do {
-            let array: [DiaryModel] = try CoreDataManager.shared.read()
-            self.diaryArray = array
+            diaryArray = try CoreDataManager.shared.read().compactMap {
+                return Diary(title: $0.title ?? "",
+                             body: $0.body ?? "",
+                             createdAt: $0.createdAt,
+                             id: $0.id)
+            }
         } catch {
             print(error.localizedDescription)
         }
@@ -89,10 +93,6 @@ extension ListViewController: UITableViewDelegate {
 
 extension ListViewController: DataSendable {
     func updateView() {
-        do {
-            diaryArray = try CoreDataManager.shared.read()
-        } catch {
-            print(error.localizedDescription)
-        }
+        readDiaryDatas()
     }
 }

--- a/Diary/Controller/ListViewController.swift
+++ b/Diary/Controller/ListViewController.swift
@@ -51,7 +51,6 @@ final class ListViewController: UIViewController {
         do {
             let array: [DiaryModel] = try CoreDataManager.shared.read()
             self.diaryArray = array
-            print(diaryArray[0].id)
         } catch {
             print(error.localizedDescription)
         }

--- a/Diary/Controller/ListViewController.swift
+++ b/Diary/Controller/ListViewController.swift
@@ -8,9 +8,11 @@ import UIKit
 
 final class ListViewController: UIViewController {
     private lazy var mainView = MainView.init(frame: view.bounds)
-    private var diaryArray: [Diary] = [] {
+    private var diaryArray: [DiaryModel] = [] {
         didSet {
-            mainView.tableView.reloadData()
+            DispatchQueue.main.async {
+                self.mainView.tableView.reloadData()
+            }
         }
     }
     

--- a/Diary/Controller/ListViewController.swift
+++ b/Diary/Controller/ListViewController.swift
@@ -90,6 +90,36 @@ extension ListViewController: UITableViewDelegate {
         editViewController.delegate = self
         self.navigationController?.pushViewController(editViewController, animated: true)
     }
+    
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        let share = UIContextualAction(style: .normal, title: "") { (_, _, success: @escaping (Bool) -> Void) in
+            let title = self.diaryArray[indexPath.row].title
+            let body = self.diaryArray[indexPath.row].body
+            
+            let diary = "\(title)\n\(body)"
+            let shareActivity = UIActivityViewController(activityItems: [diary], applicationActivities: nil)
+            self.present(shareActivity, animated: true)
+            success(true)
+        }
+        
+        let delete = UIContextualAction(style: .normal, title: "") { (_, _, success: @escaping (Bool) -> Void) in
+            do {
+                try CoreDataManager.shared.delete(self.diaryArray[indexPath.row])
+                self.diaryArray.remove(at: indexPath.row)
+                tableView.deleteRows(at: [indexPath], with: .fade)
+            } catch {
+                print("삭제에 실패했습니다.")
+            }
+            success(true)
+        }
+        
+        share.backgroundColor = .systemBlue
+        share.image = UIImage(systemName: "square.and.arrow.up")
+        delete.backgroundColor = .systemRed
+        delete.image = UIImage(systemName: "trash.fill")
+
+        return UISwipeActionsConfiguration(actions: [delete, share])
+    }
 }
 
 extension ListViewController: DataSendable {

--- a/Diary/Controller/ListViewController.swift
+++ b/Diary/Controller/ListViewController.swift
@@ -48,7 +48,6 @@ final class ListViewController: UIViewController {
                              createdAt: $0.createdAt,
                              id: $0.id)
             }
-            diaries.reverse()
         } catch {
             showErrorAlert("일기를 불러올 수 없습니다")
         }

--- a/Diary/Controller/ListViewController.swift
+++ b/Diary/Controller/ListViewController.swift
@@ -27,7 +27,7 @@ final class ListViewController: UIViewController {
         mainView.tableView.delegate = self
         mainView.tableView.register(ListTableViewCell.self, forCellReuseIdentifier: "\(ListTableViewCell.self)")
         configureNavigationBar()
-        appendDiary(parsedData())
+        appendDiary(diaryArray)
     }
     
     private func configureNavigationBar() {
@@ -42,37 +42,14 @@ final class ListViewController: UIViewController {
         self.navigationController?.pushViewController(addViewController, animated: true)
     }
     
-    private func parsedData() -> [DiaryData]? {
-        guard let asset = NSDataAsset(name: "sample") else {
-            return nil
+    private func appendDiary(_ data: [DiaryModel]?) {
+        do {
+            let array: [DiaryModel] = try CoreDataManager.shared.read()
+            self.diaryArray = array
+            print(diaryArray[0].id)
+        } catch {
+            print(error.localizedDescription)
         }
-        
-        let jsonDecoder = JSONDecoder()
-        
-        guard let sample = try? jsonDecoder.decode([DiaryData].self, from: asset.data) else {
-            return nil
-        }
-        
-        return sample
-    }
-    
-    private func appendDiary(_ data: [DiaryData]?) {
-        guard let diaryDatas = data else {
-            return
-        }
-        
-        let array: [Diary] = diaryDatas.compactMap { diaryData in
-            guard let doubleDate = diaryData.createdAt else {
-                return nil
-            }
-            
-            let date = Date(timeIntervalSince1970: doubleDate)
-            let stringDate = date.dateToKoreanString
-            
-            return Diary(title: diaryData.title ?? "", body: diaryData.body ?? "", createdAt: stringDate)
-        }
-        
-        self.diaryArray = array
     }
 }
 

--- a/Diary/Controller/ListViewController.swift
+++ b/Diary/Controller/ListViewController.swift
@@ -109,7 +109,7 @@ extension ListViewController: UITableViewDelegate {
                 self.diaryArray.remove(at: indexPath.row)
                 tableView.deleteRows(at: [indexPath], with: .fade)
             } catch {
-                print("삭제에 실패했습니다.")
+                self.showErrorAlert("삭제에 실패했습니다")
             }
             success(true)
         }

--- a/Diary/Controller/ListViewController.swift
+++ b/Diary/Controller/ListViewController.swift
@@ -45,6 +45,7 @@ final class ListViewController: UIViewController {
             diaryArray = try CoreDataManager.shared.read().compactMap {
                 return Diary(title: $0.title ?? "",
                              body: $0.body ?? "",
+                             text: $0.text ?? "",
                              createdAt: $0.createdAt,
                              id: $0.id)
             }

--- a/Diary/Controller/ListViewController.swift
+++ b/Diary/Controller/ListViewController.swift
@@ -40,13 +40,6 @@ final class ListViewController: UIViewController {
         self.navigationItem.rightBarButtonItem = plusButton
     }
     
-    @objc private func touchPlusButton() {
-        let addViewController = AddViewController()
-        
-        addViewController.delegate = self
-        self.navigationController?.pushViewController(addViewController, animated: true)
-    }
-    
     private func readDiaryDatas() {
         do {
             diaryArray = try CoreDataManager.shared.read().compactMap {
@@ -58,6 +51,13 @@ final class ListViewController: UIViewController {
         } catch {
             print(error.localizedDescription)
         }
+    }
+    
+    @objc private func touchPlusButton() {
+        let addViewController = AddViewController()
+        
+        addViewController.delegate = self
+        self.navigationController?.pushViewController(addViewController, animated: true)
     }
 }
 

--- a/Diary/Controller/Notification.Name+.swift
+++ b/Diary/Controller/Notification.Name+.swift
@@ -1,0 +1,12 @@
+//
+//  Notification.Name+.swift
+//  Diary
+//
+//  Created by 두기, marisol on 2022/06/21.
+//
+
+import Foundation
+
+extension Notification.Name {
+    static let sceneDidEnterBackgroundNotification = Notification.Name("sceneDidEnterBackgroundNotification")
+}

--- a/Diary/Controller/UIViewController+.swift
+++ b/Diary/Controller/UIViewController+.swift
@@ -1,0 +1,18 @@
+//
+//  UIViewController+.swift
+//  Diary
+//
+//  Created by 두기, marisol on 2022/06/22.
+//
+
+import UIKit
+
+extension UIViewController {
+    func showErrorAlert(_ message: String) {
+        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        let action = UIAlertAction(title: "확인", style: .default)
+
+        alert.addAction(action)
+        self.present(alert, animated: true)
+    }
+}

--- a/Diary/Diary.xcdatamodeld/.xccurrentversion
+++ b/Diary/Diary.xcdatamodeld/.xccurrentversion
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict/>
-</plist>

--- a/Diary/Diary.xcdatamodeld/.xccurrentversion
+++ b/Diary/Diary.xcdatamodeld/.xccurrentversion
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>_XCCurrentVersionName</key>
-	<string>Diary.xcdatamodel</string>
-</dict>
+<dict/>
 </plist>

--- a/Diary/Diary.xcdatamodeld/Diary.xcdatamodel/contents
+++ b/Diary/Diary.xcdatamodeld/Diary.xcdatamodel/contents
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="20G630" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
-    <entity name="DiaryModel" representedClassName="DiaryModel" syncable="YES" codeGenerationType="class"/>
-    <elements>
-        <element name="DiaryModel" positionX="-63" positionY="-18" width="128" height="29"/>
-    </elements>
-</model>

--- a/Diary/Diary.xcdatamodeld/Diary.xcdatamodel/contents
+++ b/Diary/Diary.xcdatamodeld/Diary.xcdatamodel/contents
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="1" systemVersion="11A491" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="false" userDefinedModelVersionIdentifier="">
-    <elements/>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="20G630" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="DiaryModel" representedClassName="DiaryModel" syncable="YES" codeGenerationType="class"/>
+    <elements>
+        <element name="DiaryModel" positionX="-63" positionY="-18" width="128" height="29"/>
+    </elements>
 </model>

--- a/Diary/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/Diary/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="20G630" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="20086" systemVersion="21E258" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="DiaryModel" representedClassName="DiaryModel" syncable="YES">
         <attribute name="body" optional="YES" attributeType="String"/>
         <attribute name="createdAt" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="title" optional="YES" attributeType="String"/>
     </entity>
     <elements>
-        <element name="DiaryModel" positionX="-54" positionY="-9" width="128" height="74"/>
+        <element name="DiaryModel" positionX="-54" positionY="-9" width="128" height="89"/>
     </elements>
 </model>

--- a/Diary/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/Diary/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -4,9 +4,10 @@
         <attribute name="body" optional="YES" attributeType="String"/>
         <attribute name="createdAt" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="text" optional="YES" attributeType="String"/>
         <attribute name="title" optional="YES" attributeType="String"/>
     </entity>
     <elements>
-        <element name="DiaryModel" positionX="-54" positionY="-9" width="128" height="89"/>
+        <element name="DiaryModel" positionX="-54" positionY="-9" width="128" height="104"/>
     </elements>
 </model>

--- a/Diary/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/Diary/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="20G630" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="DiaryModel" representedClassName="DiaryModel" syncable="YES">
+        <attribute name="body" optional="YES" attributeType="String"/>
+        <attribute name="createdAt" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+    </entity>
+    <elements>
+        <element name="DiaryModel" positionX="-54" positionY="-9" width="128" height="74"/>
+    </elements>
+</model>

--- a/Diary/Model/CoreDataManager.swift
+++ b/Diary/Model/CoreDataManager.swift
@@ -76,6 +76,7 @@ class CoreDataManager {
         do {
             let fetchResult = try context.fetch(request)
             guard let diaryToUpdate = fetchResult.first else {
+                create(diaryData)
                 return
             }
             diaryToUpdate.setValue(diaryData.title, forKey: "title")

--- a/Diary/Model/CoreDataManager.swift
+++ b/Diary/Model/CoreDataManager.swift
@@ -5,7 +5,6 @@
 //  Created by 두기, marisol on 2022/06/20.
 //
 
-import Foundation
 import CoreData
 
 final class CoreDataManager {

--- a/Diary/Model/CoreDataManager.swift
+++ b/Diary/Model/CoreDataManager.swift
@@ -67,4 +67,24 @@ class CoreDataManager {
         
         return diaryModels
     }
+    
+    func update(_ diaryData: TestData) throws {
+        let predicate = NSPredicate(format: "id == %@", diaryData.id.uuidString)
+        let request = DiaryModel.fetchRequest()
+        request.predicate = predicate
+        
+        do {
+            let fetchResult = try context.fetch(request)
+            guard let diaryToUpdate = fetchResult.first else {
+                return
+            }
+            diaryToUpdate.setValue(diaryData.title, forKey: "title")
+            diaryToUpdate.setValue(diaryData.body, forKey: "body")
+            diaryToUpdate.setValue(diaryData.createdAt, forKey: "createdAt")
+        } catch {
+            throw error
+        }
+        
+        saveContext()
+    }
 }

--- a/Diary/Model/CoreDataManager.swift
+++ b/Diary/Model/CoreDataManager.swift
@@ -49,6 +49,7 @@ final class CoreDataManager {
         let diary = NSManagedObject(entity: entity, insertInto: context)
         diary.setValue(diaryData.title, forKey: "title")
         diary.setValue(diaryData.body, forKey: "body")
+        diary.setValue(diaryData.text, forKey: "text")
         diary.setValue(diaryData.createdAt, forKey: "createdAt")
         diary.setValue(diaryData.id, forKey: "id")
         
@@ -81,6 +82,7 @@ final class CoreDataManager {
             }
             diaryToUpdate.setValue(diaryData.title, forKey: "title")
             diaryToUpdate.setValue(diaryData.body, forKey: "body")
+            diaryToUpdate.setValue(diaryData.text, forKey: "text")
             diaryToUpdate.setValue(diaryData.createdAt, forKey: "createdAt")
         } catch {
             throw error

--- a/Diary/Model/CoreDataManager.swift
+++ b/Diary/Model/CoreDataManager.swift
@@ -41,7 +41,7 @@ class CoreDataManager {
         }
     }
     
-    func create(_ diaryData: DiaryData) {
+    func create(_ diaryData: TestData) {
         guard let entity = entity else {
             return
         }
@@ -50,6 +50,7 @@ class CoreDataManager {
         diary.setValue(diaryData.title, forKey: "title")
         diary.setValue(diaryData.body, forKey: "body")
         diary.setValue(diaryData.createdAt, forKey: "createdAt")
+        diary.setValue(diaryData.id, forKey: "id")
         
         saveContext()
     }

--- a/Diary/Model/CoreDataManager.swift
+++ b/Diary/Model/CoreDataManager.swift
@@ -61,6 +61,8 @@ final class CoreDataManager {
         
         do {
             let request = DiaryModel.fetchRequest()
+            let sortDescriptor = NSSortDescriptor(key: "createdAt", ascending: false)
+            request.sortDescriptors = [sortDescriptor]
             diaryModels = try context.fetch(request)
         } catch {
             throw error

--- a/Diary/Model/CoreDataManager.swift
+++ b/Diary/Model/CoreDataManager.swift
@@ -41,7 +41,7 @@ final class CoreDataManager {
         }
     }
     
-    private func create(_ diaryData: TestData) {
+    private func create(_ diaryData: Diary) {
         guard let entity = entity else {
             return
         }
@@ -68,7 +68,7 @@ final class CoreDataManager {
         return diaryModels
     }
     
-    func update(_ diaryData: TestData) throws {
+    func update(_ diaryData: Diary) throws {
         let predicate = NSPredicate(format: "id == %@", diaryData.id.uuidString)
         let request = DiaryModel.fetchRequest()
         request.predicate = predicate
@@ -89,7 +89,7 @@ final class CoreDataManager {
         saveContext()
     }
     
-    func delete(_ diaryData: TestData) throws {
+    func delete(_ diaryData: Diary) throws {
         let predicate = NSPredicate(format: "id == %@", diaryData.id.uuidString)
         let request = DiaryModel.fetchRequest()
         request.predicate = predicate

--- a/Diary/Model/CoreDataManager.swift
+++ b/Diary/Model/CoreDataManager.swift
@@ -59,7 +59,8 @@ class CoreDataManager {
         var diaryModels: [DiaryModel] = []
         
         do {
-            diaryModels = try context.fetch(DiaryModel.fetchRequest())
+            let request = DiaryModel.fetchRequest()
+            diaryModels = try context.fetch(request)
         } catch {
             throw error
         }

--- a/Diary/Model/CoreDataManager.swift
+++ b/Diary/Model/CoreDataManager.swift
@@ -1,0 +1,56 @@
+//
+//  CoreDataManager.swift
+//  Diary
+//
+//  Created by 두기, marisol on 2022/06/20.
+//
+
+import Foundation
+import CoreData
+
+class CoreDataManager {
+    static let shared = CoreDataManager()
+    private init() {}
+    
+    lazy var persistentContainer: NSPersistentContainer = {
+        let container = NSPersistentContainer(name: "Diary")
+        container.loadPersistentStores(completionHandler: { (_, error) in
+            if let error = error as NSError? {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+        return container
+    }()
+    
+    var context: NSManagedObjectContext {
+        return persistentContainer.viewContext
+    }
+    
+    var entity: NSEntityDescription? {
+        return NSEntityDescription.entity(forEntityName: "DiaryModel", in: context)
+    }
+    
+    func saveContext() {
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                let nserror = error as NSError
+                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
+            }
+        }
+    }
+    
+    func create(_ diaryData: DiaryData) {
+        guard let entity = entity else {
+            return
+        }
+        
+        let diary = NSManagedObject(entity: entity, insertInto: context)
+        diary.setValue(diaryData.title, forKey: "title")
+        diary.setValue(diaryData.body, forKey: "body")
+        diary.setValue(diaryData.createdAt, forKey: "createdAt")
+        
+        saveContext()
+    }
+}

--- a/Diary/Model/CoreDataManager.swift
+++ b/Diary/Model/CoreDataManager.swift
@@ -13,7 +13,7 @@ final class CoreDataManager {
     private init() {}
     
     private lazy var persistentContainer: NSPersistentContainer = {
-        let container = NSPersistentContainer(name: "Diary")
+        let container = NSPersistentContainer(name: "Model")
         container.loadPersistentStores(completionHandler: { (_, error) in
             if let error = error as NSError? {
                 fatalError("Unresolved error \(error), \(error.userInfo)")

--- a/Diary/Model/CoreDataManager.swift
+++ b/Diary/Model/CoreDataManager.swift
@@ -8,11 +8,11 @@
 import Foundation
 import CoreData
 
-class CoreDataManager {
+final class CoreDataManager {
     static let shared = CoreDataManager()
     private init() {}
     
-    lazy var persistentContainer: NSPersistentContainer = {
+    private lazy var persistentContainer: NSPersistentContainer = {
         let container = NSPersistentContainer(name: "Diary")
         container.loadPersistentStores(completionHandler: { (_, error) in
             if let error = error as NSError? {
@@ -22,15 +22,15 @@ class CoreDataManager {
         return container
     }()
     
-    var context: NSManagedObjectContext {
+    private var context: NSManagedObjectContext {
         return persistentContainer.viewContext
     }
     
-    var entity: NSEntityDescription? {
+    private var entity: NSEntityDescription? {
         return NSEntityDescription.entity(forEntityName: "DiaryModel", in: context)
     }
     
-    func saveContext() {
+    private func saveContext() {
         if context.hasChanges {
             do {
                 try context.save()
@@ -41,7 +41,7 @@ class CoreDataManager {
         }
     }
     
-    func create(_ diaryData: TestData) {
+    private func create(_ diaryData: TestData) {
         guard let entity = entity else {
             return
         }

--- a/Diary/Model/CoreDataManager.swift
+++ b/Diary/Model/CoreDataManager.swift
@@ -87,4 +87,22 @@ class CoreDataManager {
         
         saveContext()
     }
+    
+    func delete(_ diaryData: TestData) throws {
+        let predicate = NSPredicate(format: "id == %@", diaryData.id.uuidString)
+        let request = DiaryModel.fetchRequest()
+        request.predicate = predicate
+        
+        do {
+            let fetchResult = try context.fetch(request)
+            guard let diaryToDelete = fetchResult.first else {
+                return
+            }
+            context.delete(diaryToDelete)
+        } catch {
+            throw error
+        }
+        
+        saveContext()
+    }
 }

--- a/Diary/Model/CoreDataManager.swift
+++ b/Diary/Model/CoreDataManager.swift
@@ -53,4 +53,16 @@ class CoreDataManager {
         
         saveContext()
     }
+    
+    func read() throws -> [DiaryModel] {
+        var diaryModels: [DiaryModel] = []
+        
+        do {
+            diaryModels = try context.fetch(DiaryModel.fetchRequest())
+        } catch {
+            throw error
+        }
+        
+        return diaryModels
+    }
 }

--- a/Diary/Model/Diary.swift
+++ b/Diary/Model/Diary.swift
@@ -1,5 +1,5 @@
 //
-//  DiaryData.swift
+//  Diary.swift
 //  Diary
 //
 //  Created by 두기, marisol on 2022/06/14.

--- a/Diary/Model/DiaryData.swift
+++ b/Diary/Model/DiaryData.swift
@@ -7,26 +7,9 @@
 
 import Foundation
 
-struct DiaryData: Decodable {
-    let title: String?
-    let body: String?
-    let createdAt: Double?
-    
-    private enum CodingKeys: String, CodingKey {
-        case title, body
-        case createdAt = "created_at"
-    }
-}
-
 struct TestData {
     let title: String
     let body: String
     let createdAt: Double
     let id: UUID
-}
-
-struct Diary {
-    let title: String
-    let body: String
-    let createdAt: String
 }

--- a/Diary/Model/DiaryData.swift
+++ b/Diary/Model/DiaryData.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 struct Diary {
-    let title: String
-    let body: String
+    var title: String
+    var body: String
     let createdAt: Double
     let id: UUID
 }

--- a/Diary/Model/DiaryData.swift
+++ b/Diary/Model/DiaryData.swift
@@ -10,6 +10,7 @@ import Foundation
 struct Diary {
     var title: String
     var body: String
+    var text: String
     let createdAt: Double
     let id: UUID
 }

--- a/Diary/Model/DiaryData.swift
+++ b/Diary/Model/DiaryData.swift
@@ -18,6 +18,13 @@ struct DiaryData: Decodable {
     }
 }
 
+struct TestData {
+    let title: String
+    let body: String
+    let createdAt: Double
+    let id: UUID
+}
+
 struct Diary {
     let title: String
     let body: String

--- a/Diary/Model/DiaryData.swift
+++ b/Diary/Model/DiaryData.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct TestData {
+struct Diary {
     let title: String
     let body: String
     let createdAt: Double

--- a/Diary/SceneDelegate.swift
+++ b/Diary/SceneDelegate.swift
@@ -32,6 +32,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {
-//        (UIApplication.shared.delegate as? AppDelegate)?.saveContext()
+        NotificationCenter.default.post(name: Notification.Name.sceneDidEnterBackgroundNotification, object: nil)
     }
 }

--- a/Diary/SceneDelegate.swift
+++ b/Diary/SceneDelegate.swift
@@ -32,6 +32,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {
-        (UIApplication.shared.delegate as? AppDelegate)?.saveContext()
+//        (UIApplication.shared.delegate as? AppDelegate)?.saveContext()
     }
 }

--- a/Diary/View/DiaryView.swift
+++ b/Diary/View/DiaryView.swift
@@ -37,11 +37,11 @@ final class DiaryView: UIView {
         addKeyboardObserver()
     }
     
-    func configureContents(diary: DiaryModel) {
+    func configureContents(diary: Diary) {
         diaryTextView.text = """
-        \(diary.title ?? "")
+        \(diary.title)
 
-        \(diary.body ?? "")
+        \(diary.body)
         """
         diaryTextView.contentOffset = CGPoint(x: 0, y: 0)
     }

--- a/Diary/View/DiaryView.swift
+++ b/Diary/View/DiaryView.swift
@@ -63,12 +63,21 @@ extension DiaryView {
     }
     
     private func addKeyboardObserver() {
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(keyboardWillShow),
+                                               name: UIResponder.keyboardWillShowNotification,
+                                               object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(keyboardWillHide),
+                                               name: UIResponder.keyboardWillHideNotification,
+                                               object: nil)
     }
     
     private func addHideButtonOnKeyboard() {
-        let barButton = UIBarButtonItem(image: UIImage(systemName: "keyboard.chevron.compact.down"), style: .plain, target: self, action: #selector(hideKeyboard))
+        let barButton = UIBarButtonItem(image: UIImage(systemName: "keyboard.chevron.compact.down"),
+                                        style: .plain,
+                                        target: self,
+                                        action: #selector(hideKeyboard))
         
         barButton.tintColor = .darkGray
         

--- a/Diary/View/DiaryView.swift
+++ b/Diary/View/DiaryView.swift
@@ -89,5 +89,5 @@ extension DiaryView {
     
     @objc private func hideKeyboard() {
         self.diaryTextView.endEditing(true)
-    }
+    }    
 }

--- a/Diary/View/DiaryView.swift
+++ b/Diary/View/DiaryView.swift
@@ -37,11 +37,11 @@ final class DiaryView: UIView {
         addKeyboardObserver()
     }
     
-    func configureContents(diary: Diary) {
+    func configureContents(diary: DiaryModel) {
         diaryTextView.text = """
-        \(diary.title)
+        \(diary.title ?? "")
 
-        \(diary.body)
+        \(diary.body ?? "")
         """
         diaryTextView.contentOffset = CGPoint(x: 0, y: 0)
     }

--- a/Diary/View/DiaryView.swift
+++ b/Diary/View/DiaryView.swift
@@ -78,7 +78,7 @@ extension DiaryView {
         
         let emptySpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
         
-        let toolBar = UIToolbar()
+        let toolBar = UIToolbar(frame: CGRect(x: 0, y: 0, width: 40, height: 0))
         
         toolBar.sizeToFit()
         toolBar.barStyle = .default

--- a/Diary/View/DiaryView.swift
+++ b/Diary/View/DiaryView.swift
@@ -18,7 +18,7 @@ final class DiaryView: UIView {
         super.init(coder: coder)
     }
     
-    private lazy var diaryTextView: UITextView = {
+    lazy var diaryTextView: UITextView = {
         let textView = UITextView()
         textView.translatesAutoresizingMaskIntoConstraints = false
         return textView

--- a/Diary/View/DiaryView.swift
+++ b/Diary/View/DiaryView.swift
@@ -38,11 +38,7 @@ final class DiaryView: UIView {
     }
     
     func configureContents(diary: Diary) {
-        diaryTextView.text = """
-        \(diary.title)
-
-        \(diary.body)
-        """
+        diaryTextView.text = diary.text
         diaryTextView.contentOffset = CGPoint(x: 0, y: 0)
     }
 }

--- a/Diary/View/ListTableViewCell.swift
+++ b/Diary/View/ListTableViewCell.swift
@@ -75,9 +75,9 @@ final class ListTableViewCell: UITableViewCell {
         self.accessoryType = .disclosureIndicator
     }
     
-    func configureContents(_ diaryArray: Diary) {
+    func configureContents(_ diaryArray: DiaryModel) {
         titleLabel.text = diaryArray.title
-        dateLabel.text = diaryArray.createdAt
+        dateLabel.text = Date(timeIntervalSince1970: diaryArray.createdAt).dateToKoreanString
         previewLabel.text = diaryArray.body
     }
 }

--- a/Diary/View/ListTableViewCell.swift
+++ b/Diary/View/ListTableViewCell.swift
@@ -75,7 +75,7 @@ final class ListTableViewCell: UITableViewCell {
         self.accessoryType = .disclosureIndicator
     }
     
-    func configureContents(_ diaryArray: DiaryModel) {
+    func configureContents(_ diaryArray: Diary) {
         titleLabel.text = diaryArray.title
         dateLabel.text = Date(timeIntervalSince1970: diaryArray.createdAt).dateToKoreanString
         previewLabel.text = diaryArray.body

--- a/DiaryModel+CoreDataClass.swift
+++ b/DiaryModel+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  DiaryModel+CoreDataClass.swift
+//  Diary
+//
+//  Created by 두기, marisol on 2022/06/20.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(DiaryModel)
+public class DiaryModel: NSManagedObject {
+
+}

--- a/DiaryModel+CoreDataProperties.swift
+++ b/DiaryModel+CoreDataProperties.swift
@@ -18,6 +18,7 @@ extension DiaryModel {
     @NSManaged public var title: String?
     @NSManaged public var body: String?
     @NSManaged public var createdAt: Double
+    @NSManaged public var id: UUID
 
 }
 

--- a/DiaryModel+CoreDataProperties.swift
+++ b/DiaryModel+CoreDataProperties.swift
@@ -17,6 +17,7 @@ extension DiaryModel {
 
     @NSManaged public var title: String?
     @NSManaged public var body: String?
+    @NSManaged public var text: String?
     @NSManaged public var createdAt: Double
     @NSManaged public var id: UUID
 

--- a/DiaryModel+CoreDataProperties.swift
+++ b/DiaryModel+CoreDataProperties.swift
@@ -1,0 +1,26 @@
+//
+//  DiaryModel+CoreDataProperties.swift
+//  Diary
+//
+//  Created by 두기, marisol on 2022/06/20.
+//
+//
+
+import Foundation
+import CoreData
+
+extension DiaryModel {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<DiaryModel> {
+        return NSFetchRequest<DiaryModel>(entityName: "DiaryModel")
+    }
+
+    @NSManaged public var title: String?
+    @NSManaged public var body: String?
+    @NSManaged public var createdAt: Double
+
+}
+
+extension DiaryModel: Identifiable {
+
+}

--- a/README.md
+++ b/README.md
@@ -86,8 +86,7 @@ view는 “정보를 보여주는 역할” 만 해야한다고 생각했다.
 
 이는 DiaryView가 DiaryViewController의 viewDidLoad가 아닌 메서드를 통해 각 뷰 요소들에게 할당해주는 방식 이어서, 
 즉, view가 로드되기 전에 뷰 요소들에게 diary요소들을 할당해주는 메서드를 호출해 주기 때문에 할당이 되지 않았던 것으로 추측하고 아래와 같이 로직을 변경했다.
-
-![](https://i.imgur.com/FxUVGUx.png)
+<img src="https://i.imgur.com/FxUVGUx.png" width="572" height="150"/>
 
 ![](https://i.imgur.com/wsKw6Vl.png)
 

--- a/README.md
+++ b/README.md
@@ -3,33 +3,46 @@ Core Data를 활용하여 로컬에 데이터를 저장하는 일기장 앱
 
 ## 🥳 팀원(마리솔 & 두기)
 
-![](https://i.imgur.com/D1eMxU3.png) <img src="https://i.imgur.com/b9JhIqK.jpg" width="250" height="350"/>
+|[마리솔](https://github.com/marisol-develop)|[두기](https://github.com/doogie97)|
+|:-:|:-:|
+|![](https://i.imgur.com/D1eMxU3.png)|<img src="https://i.imgur.com/ItogH6r.png" width="380" height="380"/>
 
-[마리솔](https://github.com/marisol-develop),[두기](https://github.com/doogie97)
 
 ## 📅 프로젝트 기간
 >2022-06-13 ~ 2022-07-01
 
 ## ⏰ 타임라인
-6/13(월): SwiftLint 설치, SwiftLint rule 설정
 
-6/14(화): 코드로 리스트뷰와 다이어리 뷰 구성, JSON 데이터 파싱
+| 날짜     | 진행 내용                                                                                     |
+| -------- | - |
+| 6/13(월) | SwiftLint 설치, SwiftLint rule 설정  |
+| 6/14(화) | 코드로 리스트뷰와 다이어리 뷰 구성, JSON 데이터 파싱 |
+| 6/14(수) | 다이어리 뷰에 데이터 할당 기능 구현, 키보드 자동스크롤 기능 구현, STEP1 PR |
+| 6/15(목) | Core Data 학습 |
+| 6/16(금) | STEP1 리팩터링 |
+| 6/20(월) | Core Data의 CRUD 구현 |
+| 6/21(화) | Core Data에서 가져온 데이터를 뷰에 띄우는 기능 구현 (DiaryViewController의 공통기능으로 구현) |
+| 6/22(수) | 일기 공유와 삭제 기능 구현 |
+| 6/23(목) | 개인 공부 |
+| 6/24(금) | STEP2 리팩터링 |
 
-6/14(수): 다이어리 뷰에 데이터 할당 기능 구현, 키보드 자동스크롤 기능 구현, STEP1 PR
+## 📱 실행 화면
 
-6/15(목): Core Data 학습
+|1. List View와 Diary View|2. 키보드 자동 스크롤 기능|
+|:-:|:-:|
+|![](https://i.imgur.com/Rcangs4.gif)|![](https://i.imgur.com/5pnZc5m.gif)|
 
-6/16(금): STEP1 리팩터링
+|3. Create(생성하기)|4. Read(읽어오기)|
+|:-:|:-:|
+|![](https://i.imgur.com/AuqnAF0.gif)|![](https://i.imgur.com/GXAfQKI.gif)|
 
-## 📱 실행 화면(기능 설명)
-### 1. List View와 Diary View
-![](https://i.imgur.com/Rcangs4.gif)
+|5. Update(수정하기)|6. Delete(삭제하기)|
+|:-:|:-:|
+|![](https://i.imgur.com/j9lKUvv.gif)|![](https://i.imgur.com/UtSg01N.gif)|
 
-### 2. 키보드 자동 스크롤 기능 
-![](https://i.imgur.com/5pnZc5m.gif)
-
-### 3. 가로모드 지원
-![](https://i.imgur.com/uU1r5WO.gif)
+|7. Share(공유하기)|
+|:-:|
+|![](https://i.imgur.com/VRtuyP1.gif)|
 
 ## 💡 트러블 슈팅
 
@@ -81,3 +94,33 @@ view는 “정보를 보여주는 역할” 만 해야한다고 생각했다.
 
 위와 같이 DiaryViewController가 init 될 때 diary를 파라미터로 받고 viewDidLoad에서 뷰 요소들에게 할당해주는 방식으로 구현 하니 정상 작동 하였다.
 
+### 📌 DiaryViewController상속을 통한 공통화
+`AddViewController`와 `EditViewController가` 동일한 뷰를 사용하고 있고, 공통으로 사용하는 메서드들이 있어서 `DiaryViewController`라는 부모 ViewController를 만들어서 자식 뷰가 상속 받도록 구현했다.
+
+1) 키보드가 내려가거나
+2) 백그라운드에 진입했을 때 
+
+자동으로 저장 또는 업데이트 해야했는데,
+cell을 선택해서 (didSelectRowAt) EditViewController에 진입했을 때에는 diary를 전달해주기 때문에, 전역변수로 선언된 diary가 nil이 아닐 때 (Edit)와
+diary가 nil일 때 (Add)로 분기 처리를 해주는 방식으로 처리했다.
+
+![](https://i.imgur.com/TQTQBBi.png)
+그리고 공통화 기능 구현 전에는 새로운 일기 내용을 저장하는 방식이
+
+textView.text -> core data에 저장하는 방식이었는데,
+이렇게 하니 공통화가 힘들어져서
+textView.text -> DiaryViewController의 diary 프로퍼티에 저장 -> 저장된 diary를 core data에 저장
+
+하는 방식으로 변경했다.
+
+### 📌 사용자가 일기를 작성할 때 생기는 여러 변수
+최초에는 textview에서 가져온 내용 중 첫 번째줄은 title, 두번째 줄은 body 이런 식으로 저장을 했었는데 사용자가 일기를 작성할 때 꼭 위와같은 형식으로 작성하지 않을것이기 때문에 그 대응을 아이폰 기본 어플인 메모 어플을 예시로 수정했다.
+
+![](https://i.imgur.com/LMMtmw7.png)
+`(대표적인 예외 케이스로는 줄바꿈 및 띄어쓰기 이후 글을 작성한 케이스)`
+
+공백을 제거하고 가장 먼저 만나는 첫 번째 글은 `title` , 두 번째 글은 `body`로 지정하는게 요구서 사항이지만 위와 같은 상황에서 일기 본문은 사용자가 위와 같은 모양을 의도하고 작성했을 것이다.
+
+그래서 저장된 `title`과 `body`는 list에 표시하기 위한 용도로만 사용하고 `text`라는 요소를 추가하여 일기화면에서는 사용자가 작성한 text 그대로를 보여줄 수 있게 했다.
+
+![](https://i.imgur.com/ar8E2qe.png)


### PR DESCRIPTION
@yoo-kie
안녕하세요 개굴!
STEP 2 PR 보냅니다🥳
이번 리뷰도 잘부탁드립니다!🙇‍♀️🙇‍♂️

## ❓ 궁금한 점

### 📌 1. DataModel의 파일 이름 변경
![](https://i.imgur.com/sgQdL8K.png)
![](https://i.imgur.com/Q6Wu665.png)

데이터 모델의 파일 이름을 변경하려고 하는데 화살표가 가리키는 곳의 이름은 바뀌었는데 네모 박스 부분은 바뀌지 않더라구요
일단은 파일을 삭제하고 새로 만들어주기는 했는데 저 이름을 바꾸려면 어떻게 해야할까요?

### 📌 2. delegate패턴을 위한 protocol의 위치와 네이밍
ListViewController가 DiaryViewController의 delegate이기 때문에
`DiaryViewControllerDelegate`이라는 프로토콜을 채택해주었는데요,
이럴 때는 Protocol의 선언 위치를 
그 프로토콜을 채택할 ListViewController에 해주는 것이 좋을까요, 아니면 프로토콜 타입의 프로퍼티를 만들 DiaryViewController에 해주는 것이 좋을까요?
현재는 프로토콜을 채택하는 곳이 아닌 사용되는 곳에서 그 프로토콜에 대해 알게 하기 위해서 아래와 같이 DiaryViewController의 상단에 선언해주었습니다.

![](https://i.imgur.com/re2HhZc.png)

그리고 보통은 프로토콜은 무엇인가를 "할 수 있다"는 의미를 담기 위해 -able로 끝나는 단어로 선언을 하곤 했는데,
여기서는 "DiaryViewController의 위임자 역할을 한다"라는 의미를 담기 위해 `DiaryViewControllerDelegate`으로 선언해주었습니다.

delegate 패턴을 위한 protocol의 위치와 네이밍에 대한 개굴의 의견이 궁금합니다!🤔

### 📌 3. 키보드 툴바 버튼의 오토레이아웃 오류 

![](https://i.imgur.com/eOpNokj.png)
키보드를 닫기 위해 키보드 툴바에 키보드를 닫는 버튼을 추가했는데 위와같이 키보드 툴바에 관한 레이아웃 오류가 발생했었습니다
그래서 찾아보니 ToolBar의 높이와 너비를 지정해주면 된다고 하는데
```swift
let toolBar = UIToolbar(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 44))
let toolBar = UIToolbar(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
let toolBar = UIToolbar(frame: CGRect(x: 0, y: 0, width: 40, height: 5000))
```
위의 값들중 어떤 값을 넣어줘도 오류가 해결되기는 했습니다만
저희가 확인해 본 바로는 width는 40 미만의 크기부터 오류가 생겼는데 height는 어떤 수를 집어 넣어도 오류가 생기지 않더라구요(-100해도 툴바만 없어질 뿐 오류는 없었음)

그래서 40이라는 수가 뭘 의미하는지와 왜 height는 아무리 수를 집어 넣어도 오류가 생기지 않는지 궁금합니다

## 🧐 고민한 점
### 📌 1. DiaryViewController상속을 통한 공통화

AddViewController와 EditViewController가 동일한 뷰를 사용하고 있고, 공통으로 사용하는 메서드들이 있어서 DiaryViewController라는 부모 ViewController를 만들어서 자식 뷰가 상속 받도록 구현했습니다.

키보드가 내려가거나, 백그라운드에 진입했을 때 자동으로 저장 / 업데이트 해야했었는데,
cell을 선택해서 (didSelectRowAt) EditViewController에 진입했을 때에는 diary를 전달해주기 때문에, 전역변수로 선언된 diary가 nil이 아닐 때 (Edit)와
diary가 nil일 때 (Add)로 분기 처리를 해주었습니다.

![](https://i.imgur.com/0Qm9qrL.png)

그리고 공통화 기능 구현 전에는 새로운 일기 내용을 저장하는 방식이

textView.text -> core data에 저장하는 방식이었는데, 
이렇게 하니 공통화가 힘들어져서
textView.text -> DiaryViewController의 diary 프로퍼티에 저장 -> 저장된 diary를 core data에 저장 

이런 방식으로 수정했습니다.

### 📌 2. 사용자가 일기를 저장하는 형식에 있어서의 여러 변수

최초에는 textview에서 가져온 내용 중 첫 번째줄은 title, 두번째 줄은 body 이런 식으로 저장을 했었습니다

그러나 만약 사용자가 일기를 작성할 때 꼭 저 형식으로 작성하지 않을 뿐더러 여러가지의 변수가 있어 그 대응을 아이폰 기본 어플인 메모 어플을 예시로 하나하나 수정해나갔습니다

대표적으로는 `줄바꿈 및 띄어쓰기 이후 text를 작성한 케이스`가 있습니다

![](https://i.imgur.com/mi6wzbl.png)

공백을 제거하고 가장 먼저 만나는 첫 번째 글은 title , 두 번째 글은 body로 지정하는게 요구서 사항이지만 위와 같은 상황에서 일기 본문은 사용자가 위와 같은 모양을 의도하고 작성했을거라 생각합니다

그래서 diary의 title과 body는 list에 표시하기 위한 용도로만 사용하고 text요소를 추가하여 일기화면에서는 사용자가 작성한 text 그대로를 보여줄 수 있게 하였습니다
![](https://i.imgur.com/UmDjYgh.png)

### 📌 3. 얼럿 기능 공통화를 위한 UIViewController extension

ListViewController와 DiaryViewController에서 오류 처리를 위해 얼럿을 띄워주고자 했는데요, 
공통화를 위해 UIViewController를 extension해서 `showErrorAlert(_ message: String)`를 구현해주었습니다.
그래서 alert을 생성할 때 message 부분만 받아와서 self에서 alert을 present할 수 있도록 구현했습니다.

![](https://i.imgur.com/T25r4Zm.png)

![](https://i.imgur.com/3Tix5Zs.png)

![](https://i.imgur.com/rnUsUEl.png)
