### PR TITLE
일기장 [STEP 2-2] Lingo, Minseong

### DIFF
--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		C739AE34284DF28600741E8F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C739AE32284DF28600741E8F /* LaunchScreen.storyboard */; };
 		E51F942B2863311C004623DA /* DiaryStorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E51F942A2863311C004623DA /* DiaryStorageManager.swift */; };
 		E51F942D28634CCC004623DA /* PersistentManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E51F942C28634CCC004623DA /* PersistentManagerTests.swift */; };
+		E51F942F2865E771004623DA /* DiaryStorageNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = E51F942E2865E771004623DA /* DiaryStorageNotification.swift */; };
 		E526BE05285D80CB00BD2D94 /* UIEdgeInsets+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E526BE04285D80CB00BD2D94 /* UIEdgeInsets+Extension.swift */; };
 		E5453F9A2858A4BF0073D7BA /* DiaryDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5453F992858A4BF0073D7BA /* DiaryDetailViewController.swift */; };
 		E5AE00EF285C5C980046E430 /* Then.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5AE00EE285C5C980046E430 /* Then.swift */; };
@@ -59,6 +60,7 @@
 		D8DF27F5B0E514DB780E811B /* Pods_Diary.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Diary.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E51F942A2863311C004623DA /* DiaryStorageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryStorageManager.swift; sourceTree = "<group>"; };
 		E51F942C28634CCC004623DA /* PersistentManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistentManagerTests.swift; sourceTree = "<group>"; };
+		E51F942E2865E771004623DA /* DiaryStorageNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryStorageNotification.swift; sourceTree = "<group>"; };
 		E526BE04285D80CB00BD2D94 /* UIEdgeInsets+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIEdgeInsets+Extension.swift"; sourceTree = "<group>"; };
 		E5453F992858A4BF0073D7BA /* DiaryDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryDetailViewController.swift; sourceTree = "<group>"; };
 		E5AE00EE285C5C980046E430 /* Then.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Then.swift; sourceTree = "<group>"; };
@@ -166,6 +168,7 @@
 				E51F942A2863311C004623DA /* DiaryStorageManager.swift */,
 				B0B8BE35285C75B30086190C /* Formatter.swift */,
 				E5AE00EE285C5C980046E430 /* Then.swift */,
+				E51F942E2865E771004623DA /* DiaryStorageNotification.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -368,6 +371,7 @@
 				E526BE05285D80CB00BD2D94 /* UIEdgeInsets+Extension.swift in Sources */,
 				B0B8459E28585AD7000775F3 /* Diary.swift in Sources */,
 				E5AE00EF285C5C980046E430 /* Then.swift in Sources */,
+				E51F942F2865E771004623DA /* DiaryStorageNotification.swift in Sources */,
 				B0B8BE36285C75B30086190C /* Formatter.swift in Sources */,
 				E51F942B2863311C004623DA /* DiaryStorageManager.swift in Sources */,
 				E5FF9D5B286194270049F9E6 /* DiaryBaseViewController.swift in Sources */,

--- a/Diary/Application/SceneDelegate.swift
+++ b/Diary/Application/SceneDelegate.swift
@@ -23,6 +23,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   }
 
   func sceneDidEnterBackground(_ scene: UIScene) {
-    DiaryStorageManager.shared.saveContext()
+    NotificationCenter.default.post(name: DiaryStorageManager.saveNotification, object: nil)
   }
 }

--- a/Diary/Application/SceneDelegate.swift
+++ b/Diary/Application/SceneDelegate.swift
@@ -21,8 +21,4 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     )
     self.window?.makeKeyAndVisible()
   }
-
-  func sceneDidEnterBackground(_ scene: UIScene) {
-    NotificationCenter.default.post(name: DiaryStorageManager.saveNotification, object: nil)
-  }
 }

--- a/Diary/Controller/DiaryAddViewController.swift
+++ b/Diary/Controller/DiaryAddViewController.swift
@@ -38,7 +38,7 @@ final class DiaryAddViewController: DiaryBaseViewController {
       DiaryStorageManager.shared.create(
         diary: Diary(title: title, body: body, createdAt: Date().timeIntervalSince1970)
       )
-      NotificationCenter.default.post(name: DiaryStorageNotification.diaryDidSave, object: nil)
+      NotificationCenter.default.post(name: DiaryStorageNotification.diaryWasSaved, object: nil)
     }
   }
 }

--- a/Diary/Controller/DiaryAddViewController.swift
+++ b/Diary/Controller/DiaryAddViewController.swift
@@ -12,4 +12,22 @@ final class DiaryAddViewController: DiaryBaseViewController {
     super.viewDidLoad()
     bodyTextView.becomeFirstResponder()
   }
+
+  override func viewDidDisappear(_ animated: Bool) {
+    super.viewWillDisappear(animated)
+    self.saveDiary()
+  }
+
+  private func saveDiary() {
+    var text = bodyTextView.text.components(separatedBy: "\n")
+    let title = text.first
+    text.removeFirst()
+    let body = text.joined(separator: "\n")
+
+    if let title = title, !title.isEmpty {
+      DiaryStorageManager.shared.create(
+        diary: Diary(title: title, body: body, createdAt: 0)
+      )
+    }
+  }
 }

--- a/Diary/Controller/DiaryAddViewController.swift
+++ b/Diary/Controller/DiaryAddViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 final class DiaryAddViewController: DiaryBaseViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
-    bodyTextView.becomeFirstResponder()
+    self.bodyTextView.becomeFirstResponder()
   }
 
   override func viewDidDisappear(_ animated: Bool) {
@@ -19,15 +19,16 @@ final class DiaryAddViewController: DiaryBaseViewController {
   }
 
   private func saveDiary() {
-    var text = bodyTextView.text.components(separatedBy: "\n")
+    var text = self.bodyTextView.text.components(separatedBy: "\n")
     let title = text.first
     text.removeFirst()
     let body = text.joined(separator: "\n")
 
     if let title = title, !title.isEmpty {
       DiaryStorageManager.shared.create(
-        diary: Diary(title: title, body: body, createdAt: 0)
+        diary: Diary(title: title, body: body, createdAt: Date().timeIntervalSince1970)
       )
+      NotificationCenter.default.post(name: DiaryStorageManager.fetchNotification, object: nil)
     }
   }
 }

--- a/Diary/Controller/DiaryAddViewController.swift
+++ b/Diary/Controller/DiaryAddViewController.swift
@@ -38,7 +38,6 @@ final class DiaryAddViewController: DiaryBaseViewController {
       DiaryStorageManager.shared.create(
         diary: Diary(title: title, body: body, createdAt: Date().timeIntervalSince1970)
       )
-      NotificationCenter.default.post(name: DiaryStorageNotification.diaryWasSaved, object: nil)
     }
   }
 }

--- a/Diary/Controller/DiaryAddViewController.swift
+++ b/Diary/Controller/DiaryAddViewController.swift
@@ -11,6 +11,7 @@ final class DiaryAddViewController: DiaryBaseViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     self.bodyTextView.becomeFirstResponder()
+    self.observeDidEnterBackgroundNotification()
   }
 
   override func viewDidDisappear(_ animated: Bool) {
@@ -18,7 +19,16 @@ final class DiaryAddViewController: DiaryBaseViewController {
     self.saveDiary()
   }
 
-  private func saveDiary() {
+  private func observeDidEnterBackgroundNotification() {
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(self.saveDiary),
+      name: UIApplication.didEnterBackgroundNotification,
+      object: nil
+    )
+  }
+
+  @objc private func saveDiary() {
     var text = self.bodyTextView.text.components(separatedBy: "\n")
     let title = text.first
     text.removeFirst()
@@ -28,7 +38,7 @@ final class DiaryAddViewController: DiaryBaseViewController {
       DiaryStorageManager.shared.create(
         diary: Diary(title: title, body: body, createdAt: Date().timeIntervalSince1970)
       )
-      NotificationCenter.default.post(name: DiaryStorageManager.fetchNotification, object: nil)
+      NotificationCenter.default.post(name: DiaryStorageNotification.diaryDidSave, object: nil)
     }
   }
 }

--- a/Diary/Controller/DiaryAddViewController.swift
+++ b/Diary/Controller/DiaryAddViewController.swift
@@ -10,5 +10,6 @@ import UIKit
 final class DiaryAddViewController: DiaryBaseViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
+    bodyTextView.becomeFirstResponder()
   }
 }

--- a/Diary/Controller/DiaryAddViewController.swift
+++ b/Diary/Controller/DiaryAddViewController.swift
@@ -16,19 +16,19 @@ final class DiaryAddViewController: DiaryBaseViewController {
 
   override func viewDidDisappear(_ animated: Bool) {
     super.viewWillDisappear(animated)
-    self.saveDiary()
+    self.createDiary()
   }
 
   private func observeDidEnterBackgroundNotification() {
     NotificationCenter.default.addObserver(
       self,
-      selector: #selector(self.saveDiary),
+      selector: #selector(self.createDiary),
       name: UIApplication.didEnterBackgroundNotification,
       object: nil
     )
   }
 
-  @objc private func saveDiary() {
+  @objc private func createDiary() {
     var text = self.bodyTextView.text.components(separatedBy: "\n")
     let title = text.first
     text.removeFirst()

--- a/Diary/Controller/DiaryBaseViewController.swift
+++ b/Diary/Controller/DiaryBaseViewController.swift
@@ -69,7 +69,7 @@ class DiaryBaseViewController: UIViewController {
     keyboardDownButton.tintColor = .label
     toolbar.setItems([UIBarButtonItem.flexibleSpace(), keyboardDownButton], animated: true)
     toolbar.sizeToFit()
-    bodyTextView.inputAccessoryView = toolbar
+    self.bodyTextView.inputAccessoryView = toolbar
   }
 
   @objc func keyboardDownDidTap(_ sender: UIBarButtonItem) {

--- a/Diary/Controller/DiaryBaseViewController.swift
+++ b/Diary/Controller/DiaryBaseViewController.swift
@@ -18,6 +18,7 @@ class DiaryBaseViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     self.initializeUI()
+    self.initializeKeyboardToolbar()
     self.observeKeyboardNotifications()
   }
 
@@ -54,6 +55,25 @@ class DiaryBaseViewController: UIViewController {
       self.bodyTextView.widthAnchor.constraint(equalTo: container.widthAnchor),
       self.bodyTextView.heightAnchor.constraint(equalTo: container.heightAnchor, constant: 1)
     ])
+  }
+
+  private func initializeKeyboardToolbar() {
+    let toolbarFrame = CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 35)
+    let toolbar = UIToolbar(frame: toolbarFrame)
+    let keyboardDownButton = UIBarButtonItem(
+      image: UIImage(systemName: "keyboard.chevron.compact.down"),
+      style: .done,
+      target: self,
+      action: #selector(keyboardDownDidTap)
+    )
+    keyboardDownButton.tintColor = .label
+    toolbar.setItems([UIBarButtonItem.flexibleSpace(), keyboardDownButton], animated: true)
+    toolbar.sizeToFit()
+    bodyTextView.inputAccessoryView = toolbar
+  }
+
+  @objc func keyboardDownDidTap(_ sender: UIBarButtonItem) {
+    self.bodyTextView.endEditing(true)
   }
 
   private func observeKeyboardNotifications() {

--- a/Diary/Controller/DiaryDetailViewController.swift
+++ b/Diary/Controller/DiaryDetailViewController.swift
@@ -58,7 +58,6 @@ final class DiaryDetailViewController: DiaryBaseViewController {
     self.diary.title = title
     self.diary.body = body
 
-    DiaryStorageManager.shared.saveContext()
-    NotificationCenter.default.post(name: DiaryStorageNotification.diaryDidSave, object: nil)
+    DiaryStorageManager.shared.update()
   }
 }

--- a/Diary/Controller/DiaryDetailViewController.swift
+++ b/Diary/Controller/DiaryDetailViewController.swift
@@ -21,7 +21,7 @@ final class DiaryDetailViewController: DiaryBaseViewController {
     super.viewDidLoad()
     self.initializeNavigationBar()
     self.initializeItem()
-    self.observePersistentNotification()
+    self.observeDiaryDidUpdateNotifications()
   }
 
   private func initializeNavigationBar() {
@@ -34,7 +34,7 @@ final class DiaryDetailViewController: DiaryBaseViewController {
     self.bodyTextView.text = title + "\n" + body
   }
 
-  private func observePersistentNotification() {
+  private func observeDiaryDidUpdateNotifications() {
     NotificationCenter.default.addObserver(
       self,
       selector: #selector(self.updateDiary),

--- a/Diary/Controller/DiaryDetailViewController.swift
+++ b/Diary/Controller/DiaryDetailViewController.swift
@@ -6,9 +6,9 @@
 import UIKit
 
 final class DiaryDetailViewController: DiaryBaseViewController {
-  private let diary: Diary
+  private let diary: DiaryEntity
 
-  init(diary: Diary) {
+  init(diary: DiaryEntity) {
     self.diary = diary
     super.init(nibName: nil, bundle: nil)
   }
@@ -28,6 +28,8 @@ final class DiaryDetailViewController: DiaryBaseViewController {
   }
 
   private func initializeItem() {
-    self.bodyTextView.text = self.diary.title + "\n\n" + self.diary.body
+    guard let title = diary.title, let body = diary.body else { return }
+
+    self.bodyTextView.text = title + "\n\n" + body
   }
 }

--- a/Diary/Controller/DiaryDetailViewController.swift
+++ b/Diary/Controller/DiaryDetailViewController.swift
@@ -22,7 +22,6 @@ final class DiaryDetailViewController: DiaryBaseViewController {
     self.initializeNavigationBar()
     self.initializeItem()
     self.observePersistentNotification()
-    self.bodyTextView.delegate = self
   }
 
   private func initializeNavigationBar() {
@@ -34,20 +33,20 @@ final class DiaryDetailViewController: DiaryBaseViewController {
 
     self.bodyTextView.text = title + "\n" + body
   }
-}
-
-extension DiaryDetailViewController: UITextViewDelegate {
-  func textViewDidEndEditing(_ textView: UITextView) {
-    NotificationCenter.default.post(name: DiaryStorageManager.saveNotification, object: nil)
-  }
 
   private func observePersistentNotification() {
     NotificationCenter.default.addObserver(
       self,
       selector: #selector(self.updateDiary),
-      name: DiaryStorageManager.saveNotification,
+      name: UITextView.textDidEndEditingNotification,
       object: nil
     )
+
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(self.updateDiary),
+      name: UIApplication.didEnterBackgroundNotification,
+      object: nil)
   }
 
   @objc private func updateDiary() {
@@ -60,6 +59,6 @@ extension DiaryDetailViewController: UITextViewDelegate {
     self.diary.body = body
 
     DiaryStorageManager.shared.saveContext()
-    NotificationCenter.default.post(name: DiaryStorageManager.fetchNotification, object: nil)
+    NotificationCenter.default.post(name: DiaryStorageNotification.diaryDidSave, object: nil)
   }
 }

--- a/Diary/Controller/DiaryDetailViewController.swift
+++ b/Diary/Controller/DiaryDetailViewController.swift
@@ -32,7 +32,7 @@ final class DiaryDetailViewController: DiaryBaseViewController {
   private func initializeItem() {
     guard let title = self.diary.title, let body = self.diary.body else { return }
 
-    self.bodyTextView.text = title + "\n\n" + body
+    self.bodyTextView.text = title + "\n" + body
   }
 }
 

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -60,7 +60,7 @@ final class DiaryViewController: UIViewController {
   }
 
   @objc private func fetchDiaries() {
-    self.diaries = DiaryStorageManager.shared.fetchAll()
+    self.diaries = DiaryStorageManager.shared.fetchAllDiaries()
   }
 
   private func observePersistentNotification() {

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -15,13 +15,20 @@ final class DiaryViewController: UIViewController {
     )
   }
 
-  private var diaries = [DiaryEntity]()
+  private var diaries = [DiaryEntity]() {
+    didSet {
+      DispatchQueue.main.async {
+        self.diaryTableView.reloadData()
+      }
+    }
+  }
 
   override func viewDidLoad() {
     super.viewDidLoad()
     self.initializeUI()
     self.initializeNavigationBar()
     self.fetchDiaries()
+    self.observePersistentNotification()
   }
 
   private func initializeUI() {
@@ -52,8 +59,17 @@ final class DiaryViewController: UIViewController {
     self.navigationController?.pushViewController(addViewController, animated: true)
   }
 
-  private func fetchDiaries() {
+  @objc private func fetchDiaries() {
     self.diaries = DiaryStorageManager.shared.fetchAll()
+  }
+
+  private func observePersistentNotification() {
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(self.fetchDiaries),
+      name: DiaryStorageManager.fetchNotification,
+      object: nil
+    )
   }
 }
 

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -15,7 +15,7 @@ final class DiaryViewController: UIViewController {
     )
   }
 
-  private var diaries = [Diary]()
+  private var diaries = [DiaryEntity]()
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -53,8 +53,7 @@ final class DiaryViewController: UIViewController {
   }
 
   private func fetchDiaries() {
-    guard let result = Parser.decode(type: [Diary].self, assetName: "sample") else { return }
-    self.diaries = result
+    self.diaries = DiaryStorageManager.shared.fetchAll()
   }
 }
 

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -67,7 +67,7 @@ final class DiaryViewController: UIViewController {
     NotificationCenter.default.addObserver(
       self,
       selector: #selector(self.fetchDiaries),
-      name: DiaryStorageManager.fetchNotification,
+      name: DiaryStorageNotification.diaryDidSave,
       object: nil
     )
   }

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -67,7 +67,7 @@ final class DiaryViewController: UIViewController {
     NotificationCenter.default.addObserver(
       self,
       selector: #selector(self.fetchDiaries),
-      name: DiaryStorageNotification.diaryDidSave,
+      name: DiaryStorageNotification.diaryWasSaved,
       object: nil
     )
   }

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -28,7 +28,7 @@ final class DiaryViewController: UIViewController {
     self.initializeUI()
     self.initializeNavigationBar()
     self.fetchDiaries()
-    self.observePersistentNotification()
+    self.observeDiaryDidSaveNotification()
   }
 
   private func initializeUI() {
@@ -63,7 +63,7 @@ final class DiaryViewController: UIViewController {
     self.diaries = DiaryStorageManager.shared.fetchAllDiaries()
   }
 
-  private func observePersistentNotification() {
+  private func observeDiaryDidSaveNotification() {
     NotificationCenter.default.addObserver(
       self,
       selector: #selector(self.fetchDiaries),

--- a/Diary/Util/DiaryStorageManager.swift
+++ b/Diary/Util/DiaryStorageManager.swift
@@ -46,6 +46,7 @@ final class DiaryStorageManager {
     diaryEntity.setValue(diary.uuid, forKey: "uuid")
 
     self.saveContext()
+    NotificationCenter.default.post(name: DiaryStorageNotification.diaryWasSaved, object: nil)
   }
 
   func fetchAllDiaries() -> [DiaryEntity] {

--- a/Diary/Util/DiaryStorageManager.swift
+++ b/Diary/Util/DiaryStorageManager.swift
@@ -53,14 +53,9 @@ final class DiaryStorageManager {
     return diaryEntities
   }
 
-  func update(diary: Diary) {
-    guard let diaryEntities = try? self.context.fetch(DiaryEntity.fetchRequest()) else { return }
-    guard let diaryEntity = diaryEntities.first(where: { $0.uuid == diary.uuid }) else { return }
-
-    diaryEntity.setValue(diary.title, forKey: "title")
-    diaryEntity.setValue(diary.body, forKey: "body")
-
+  func update() {
     self.saveContext()
+    NotificationCenter.default.post(name: DiaryStorageNotification.diaryDidSave, object: nil)
   }
 
   func delete(diary: Diary) {

--- a/Diary/Util/DiaryStorageManager.swift
+++ b/Diary/Util/DiaryStorageManager.swift
@@ -48,14 +48,9 @@ final class DiaryStorageManager {
     self.saveContext()
   }
 
-  func fetchAll() -> [Diary] {
-    guard let diaryEntities = try? self.context.fetch(DiaryEntity.fetchRequest()) else { return [] }
-
-    let diaries = diaryEntities.map {
-      Diary(title: $0.title ?? "", body: $0.body ?? "", createdAt: $0.createdAt)
-    }
-
-    return diaries
+  func fetchAll() -> [DiaryEntity] {
+    guard let diaryEntities = try? context.fetch(DiaryEntity.fetchRequest()) else { return [] }
+    return diaryEntities
   }
 
   func update(diary: Diary) {

--- a/Diary/Util/DiaryStorageManager.swift
+++ b/Diary/Util/DiaryStorageManager.swift
@@ -82,8 +82,3 @@ final class DiaryStorageManager {
     self.saveContext()
   }
 }
-
-extension DiaryStorageManager {
-  static let fetchNotification = NSNotification.Name("PersistentFetch")
-  static let saveNotification = NSNotification.Name("PersistentBackgroundSave")
-}

--- a/Diary/Util/DiaryStorageManager.swift
+++ b/Diary/Util/DiaryStorageManager.swift
@@ -82,3 +82,8 @@ final class DiaryStorageManager {
     self.saveContext()
   }
 }
+
+extension DiaryStorageManager {
+  static let fetchNotification = NSNotification.Name("PersistentFetch")
+  static let saveNotification = NSNotification.Name("PersistentBackgroundSave")
+}

--- a/Diary/Util/DiaryStorageManager.swift
+++ b/Diary/Util/DiaryStorageManager.swift
@@ -55,7 +55,7 @@ final class DiaryStorageManager {
 
   func update() {
     self.saveContext()
-    NotificationCenter.default.post(name: DiaryStorageNotification.diaryDidSave, object: nil)
+    NotificationCenter.default.post(name: DiaryStorageNotification.diaryWasSaved, object: nil)
   }
 
   func delete(diary: Diary) {

--- a/Diary/Util/DiaryStorageManager.swift
+++ b/Diary/Util/DiaryStorageManager.swift
@@ -48,7 +48,7 @@ final class DiaryStorageManager {
     self.saveContext()
   }
 
-  func fetchAll() -> [DiaryEntity] {
+  func fetchAllDiaries() -> [DiaryEntity] {
     guard let diaryEntities = try? context.fetch(DiaryEntity.fetchRequest()) else { return [] }
     return diaryEntities
   }

--- a/Diary/Util/DiaryStorageNotification.swift
+++ b/Diary/Util/DiaryStorageNotification.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 enum DiaryStorageNotification {
-  static let diaryDidSave = NSNotification.Name("DiaryStorageDidSaveNotification")
+  static let diaryWasSaved = NSNotification.Name("DiaryStorageWasSavedNotification")
 }

--- a/Diary/Util/DiaryStorageNotification.swift
+++ b/Diary/Util/DiaryStorageNotification.swift
@@ -1,0 +1,8 @@
+//
+//  DiaryStorageNotification.swift
+//  Diary
+//
+//  Created by Minseong, Lingo on 2022/06/24.
+//
+
+import Foundation

--- a/Diary/Util/DiaryStorageNotification.swift
+++ b/Diary/Util/DiaryStorageNotification.swift
@@ -6,3 +6,7 @@
 //
 
 import Foundation
+
+enum DiaryStorageNotification {
+  static let diaryDidSave = NSNotification.Name("DiaryStorageDidSaveNotification")
+}

--- a/Diary/View/DiaryTableViewCell.swift
+++ b/Diary/View/DiaryTableViewCell.swift
@@ -41,7 +41,7 @@ final class DiaryTableViewCell: UITableViewCell {
     self.dateLabel.text = nil
   }
 
-  func configureItem(_ diary: Diary) {
+  func configureItem(_ diary: DiaryEntity) {
     self.titleLabel.text = diary.title
     self.bodyLabel.text = diary.body
     self.dateLabel.text = Formatter.changeToString(from: diary.createdAt)


### PR DESCRIPTION
@innocarpe

## 배경
- Step 1-1의 리스트 화면에서 + 버튼을 터치하면 일기를 생성하고 Step 1-2의 일기 화면에서 일기를 편집합니다
    - 이 때는 키보드를 자동으로 보여줍니다
- Step 1-1의 리스트 화면에서 지난 일기를 터치하면 일기 화면으로 이동하고, 텍스트 영역을 터치하면 일기를 편집합니다
- 일기는 자동저장합니다
    - 사용자가 입력을 멈추는 경우(키보드가 사라지는 경우)
    - 앱이 백그라운드로 진입하는 경우
    - 이전 화면(리스트 화면)으로 이동하는 경우
- 일기의 맨 첫 줄은 일기의 제목이 되고, 그 다음 줄부터 본문이 됩니다

위 요구사항을 구현하였습니다.

---

## 작업 내용
- 일기 생성화면에서 일기를 편집할 수 있는 기능을 구현하였습니다.
  - 이때 `TextView`의 `becomeFirstResponder()`를 통해 키보드가 자동으로 보여주는 기능을 구현해주었습니다.
- 지난 일기를 편집하는 기능을 구현하였습니다.
- 일기 자동 저장기능을 구현하였습니다. 이때 자동 저장의 조건은 아래와 같습니다.
  - 사용자가 입력을 멈추는 경우(키보드가 사라지는 경우)
    - `UITextViewDelegate`를 채택하여 `textViewDidEndEditing` 메서드를 사용해 구현하였습니다.
  - 앱이 백그라운드로 진입하는 경우
    - `SceneDelegate`의 `sceneDidEnterBackground`메서드에서 `Notification post`를 사용해 구현하였습니다.
  - 이전 화면(리스트 화면)으로 이동하는 경우
    - 생성 화면의 경우 `viewWillDisappear` 메서드가 호출되는 시점에서 저장하도록 구현했습니다.
    - 상세 화면(Detail)의 경우 이전 화면으로 이동할 때 TextView의 `textViewDidEndEditing`이 호출되기 때문에 해당 메서드로 처리하여 구현했습니다. (사용자가 입력을 멈춰 키보드가 사라지는 경우와 동일)
- `\n`를 기준으로 텍스트를 나눠 첫 `index`요소를 title로 할당해주었습니다.
- `removeFirst()`로 첫 `index`요소를 제거한 후 `joined(separator: "\n")`해주어 body를 할당해주었습니다.

---

### 리뷰 노트
Parser와 Formatter에서 각각 JSONDecoder와 DateFormatter를 정적 프로퍼티(`static let`)로 구현했는데 `메서드 실행마다 인스턴스 생성하는 것`과 `정적 프로퍼티로 한번만 생성하여 공유하여 사용하는 것` 중 어느 것이 좋은 방향인지 궁금합니다!

---

### 스크린샷 및 영상

|[생성 화면] 일기장 생성 기능|[상세 화면 - 수정] 키보드를 내렸을때 자동 저장|
|:---:|:---:|
|![](https://i.imgur.com/PkeKmXp.gif)|![](https://i.imgur.com/2uhqXi2.gif)|

|[상세 화면 - 수정] 백그라운드 자동 저장|[상세 화면 - 수정] 이전 화면으로 갈때 자동 저장|
|:---:|:---:|
|![](https://i.imgur.com/eIYHWNq.gif)|![](https://i.imgur.com/tUPSpmW.gif)|

