### PR TITLE
일기장 [STEP 3] Finnn, 수꿍

### DIFF
--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -164,9 +164,9 @@
 		20DF026328AB75B1005AA6FA /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				B45EAB7728B9E7BB0066F2E8 /* WeatherDataEntity.swift */,
 				20DF026628AB7733005AA6FA /* DiarySampleData.swift */,
 				20DF026428AB769F005AA6FA /* JSONData.swift */,
+				B45EAB7728B9E7BB0066F2E8 /* WeatherDataEntity.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -17,8 +17,6 @@
 		209A338C28AE25AD007C7BB3 /* AssetData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209A338B28AE25AD007C7BB3 /* AssetData.swift */; };
 		209A338E28AE35AD007C7BB3 /* Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209A338D28AE35AD007C7BB3 /* Alert.swift */; };
 		209A339028AE3660007C7BB3 /* NavigationItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209A338F28AE3660007C7BB3 /* NavigationItem.swift */; };
-		20D20EAF28B8A94700A6CACC /* Diary+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D20EAD28B8A94700A6CACC /* Diary+CoreDataClass.swift */; };
-		20D20EB028B8A94700A6CACC /* Diary+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D20EAE28B8A94700A6CACC /* Diary+CoreDataProperties.swift */; };
 		20DF026528AB769F005AA6FA /* JSONData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20DF026428AB769F005AA6FA /* JSONData.swift */; };
 		20DF026728AB7733005AA6FA /* DiarySampleData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20DF026628AB7733005AA6FA /* DiarySampleData.swift */; };
 		20DF026928AB893F005AA6FA /* DiaryListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20DF026828AB893F005AA6FA /* DiaryListCell.swift */; };
@@ -27,8 +25,22 @@
 		20DF026F28ABA780005AA6FA /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20DF026E28ABA780005AA6FA /* Date+Extension.swift */; };
 		20DF027128ABA80A005AA6FA /* DiaryContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20DF027028ABA80A005AA6FA /* DiaryContentView.swift */; };
 		B42AD02528ACB226008933E3 /* SystemImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42AD02428ACB226008933E3 /* SystemImage.swift */; };
+		B45EAB7628B9E6240066F2E8 /* WeatherImageAPIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45EAB7528B9E6240066F2E8 /* WeatherImageAPIManager.swift */; };
+		B45EAB7828B9E7BB0066F2E8 /* WeatherDataEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45EAB7728B9E7BB0066F2E8 /* WeatherDataEntity.swift */; };
 		B47277D128AE10DC000075CC /* ParsingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47277D028AE10DC000075CC /* ParsingError.swift */; };
 		B478312C28AB923100CBB8DA /* Int+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B478312B28AB923100CBB8DA /* Int+Extension.swift */; };
+		B4CE5B0128BC8F1D00E3A1D1 /* Diary+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CE5AFF28BC8F1D00E3A1D1 /* Diary+CoreDataClass.swift */; };
+		B4CE5B0228BC8F1D00E3A1D1 /* Diary+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CE5B0028BC8F1D00E3A1D1 /* Diary+CoreDataProperties.swift */; };
+		B4CE5B0828BCAA4E00E3A1D1 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CE5B0728BCAA4E00E3A1D1 /* APIError.swift */; };
+		B4CE5B0A28BCAA7900E3A1D1 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CE5B0928BCAA7900E3A1D1 /* HTTPMethod.swift */; };
+		B4CE5B0C28BCAA9A00E3A1D1 /* WeatherURLQueryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CE5B0B28BCAA9A00E3A1D1 /* WeatherURLQueryItem.swift */; };
+		B4CE5B0E28BCAABB00E3A1D1 /* URLComponentsBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CE5B0D28BCAABB00E3A1D1 /* URLComponentsBuilder.swift */; };
+		B4CE5B1028BCAB3F00E3A1D1 /* URLComponents+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CE5B0F28BCAB3F00E3A1D1 /* URLComponents+Extension.swift */; };
+		B4CE5B1228BCAB8200E3A1D1 /* APIConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CE5B1128BCAB8200E3A1D1 /* APIConfiguration.swift */; };
+		B4CE5B1428BCAB9B00E3A1D1 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CE5B1328BCAB9B00E3A1D1 /* APIClient.swift */; };
+		B4CE5B1628BCABB200E3A1D1 /* APIProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CE5B1528BCABB200E3A1D1 /* APIProtocol.swift */; };
+		B4CE5B1828BCABD500E3A1D1 /* GETProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CE5B1728BCABD500E3A1D1 /* GETProtocol.swift */; };
+		B4CE5B1A28BCABFF00E3A1D1 /* WeatherDataAPIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CE5B1928BCABFF00E3A1D1 /* WeatherDataAPIManager.swift */; };
 		C739AE25284DF28600741E8F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C739AE24284DF28600741E8F /* AppDelegate.swift */; };
 		C739AE27284DF28600741E8F /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C739AE26284DF28600741E8F /* SceneDelegate.swift */; };
 		C739AE29284DF28600741E8F /* DiaryListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C739AE28284DF28600741E8F /* DiaryListViewController.swift */; };
@@ -48,8 +60,6 @@
 		209A338B28AE25AD007C7BB3 /* AssetData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetData.swift; sourceTree = "<group>"; };
 		209A338D28AE35AD007C7BB3 /* Alert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Alert.swift; sourceTree = "<group>"; };
 		209A338F28AE3660007C7BB3 /* NavigationItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationItem.swift; sourceTree = "<group>"; };
-		20D20EAD28B8A94700A6CACC /* Diary+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Diary+CoreDataClass.swift"; sourceTree = "<group>"; };
-		20D20EAE28B8A94700A6CACC /* Diary+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Diary+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		20DF026428AB769F005AA6FA /* JSONData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONData.swift; sourceTree = "<group>"; };
 		20DF026628AB7733005AA6FA /* DiarySampleData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiarySampleData.swift; sourceTree = "<group>"; };
 		20DF026828AB893F005AA6FA /* DiaryListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListCell.swift; sourceTree = "<group>"; };
@@ -58,8 +68,22 @@
 		20DF026E28ABA780005AA6FA /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
 		20DF027028ABA80A005AA6FA /* DiaryContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryContentView.swift; sourceTree = "<group>"; };
 		B42AD02428ACB226008933E3 /* SystemImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemImage.swift; sourceTree = "<group>"; };
+		B45EAB7528B9E6240066F2E8 /* WeatherImageAPIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherImageAPIManager.swift; sourceTree = "<group>"; };
+		B45EAB7728B9E7BB0066F2E8 /* WeatherDataEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherDataEntity.swift; sourceTree = "<group>"; };
 		B47277D028AE10DC000075CC /* ParsingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParsingError.swift; sourceTree = "<group>"; };
 		B478312B28AB923100CBB8DA /* Int+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Extension.swift"; sourceTree = "<group>"; };
+		B4CE5AFF28BC8F1D00E3A1D1 /* Diary+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Diary+CoreDataClass.swift"; sourceTree = "<group>"; };
+		B4CE5B0028BC8F1D00E3A1D1 /* Diary+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Diary+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		B4CE5B0728BCAA4E00E3A1D1 /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
+		B4CE5B0928BCAA7900E3A1D1 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
+		B4CE5B0B28BCAA9A00E3A1D1 /* WeatherURLQueryItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherURLQueryItem.swift; sourceTree = "<group>"; };
+		B4CE5B0D28BCAABB00E3A1D1 /* URLComponentsBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLComponentsBuilder.swift; sourceTree = "<group>"; };
+		B4CE5B0F28BCAB3F00E3A1D1 /* URLComponents+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLComponents+Extension.swift"; sourceTree = "<group>"; };
+		B4CE5B1128BCAB8200E3A1D1 /* APIConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConfiguration.swift; sourceTree = "<group>"; };
+		B4CE5B1328BCAB9B00E3A1D1 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
+		B4CE5B1528BCABB200E3A1D1 /* APIProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIProtocol.swift; sourceTree = "<group>"; };
+		B4CE5B1728BCABD500E3A1D1 /* GETProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GETProtocol.swift; sourceTree = "<group>"; };
+		B4CE5B1928BCABFF00E3A1D1 /* WeatherDataAPIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherDataAPIManager.swift; sourceTree = "<group>"; };
 		C739AE21284DF28600741E8F /* Diary.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Diary.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C739AE24284DF28600741E8F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C739AE26284DF28600741E8F /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -85,8 +109,8 @@
 			isa = PBXGroup;
 			children = (
 				20534C2928B4B71400C5C66C /* CoreDataManager.swift */,
-				20D20EAD28B8A94700A6CACC /* Diary+CoreDataClass.swift */,
-				20D20EAE28B8A94700A6CACC /* Diary+CoreDataProperties.swift */,
+				B4CE5AFF28BC8F1D00E3A1D1 /* Diary+CoreDataClass.swift */,
+				B4CE5B0028BC8F1D00E3A1D1 /* Diary+CoreDataProperties.swift */,
 			);
 			path = CoreData;
 			sourceTree = "<group>";
@@ -94,6 +118,9 @@
 		209A338828AE22E2007C7BB3 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				B4CE5B0D28BCAABB00E3A1D1 /* URLComponentsBuilder.swift */,
+				B4CE5B1D28BCACED00E3A1D1 /* API */,
+				B4CE5B1B28BCAC5A00E3A1D1 /* WeatherManager */,
 				C739AE24284DF28600741E8F /* AppDelegate.swift */,
 				C739AE26284DF28600741E8F /* SceneDelegate.swift */,
 				20534C2828B4B6E500C5C66C /* CoreData */,
@@ -112,10 +139,12 @@
 				209A338D28AE35AD007C7BB3 /* Alert.swift */,
 				209A338B28AE25AD007C7BB3 /* AssetData.swift */,
 				202E4EBA28B5E40800AE316D /* DiaryCoreData.swift */,
+				B4CE5B0928BCAA7900E3A1D1 /* HTTPMethod.swift */,
 				209A338F28AE3660007C7BB3 /* NavigationItem.swift */,
 				202E4EBE28B5EA9000AE316D /* NewLine.swift */,
 				202E4EC028B5ECD500AE316D /* SearchControllerItem.swift */,
 				B42AD02428ACB226008933E3 /* SystemImage.swift */,
+				B4CE5B0B28BCAA9A00E3A1D1 /* WeatherURLQueryItem.swift */,
 			);
 			path = Namespaces;
 			sourceTree = "<group>";
@@ -133,6 +162,7 @@
 		20DF026328AB75B1005AA6FA /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				B45EAB7728B9E7BB0066F2E8 /* WeatherDataEntity.swift */,
 				20DF026628AB7733005AA6FA /* DiarySampleData.swift */,
 				20DF026428AB769F005AA6FA /* JSONData.swift */,
 			);
@@ -145,6 +175,7 @@
 				20DF026E28ABA780005AA6FA /* Date+Extension.swift */,
 				B478312B28AB923100CBB8DA /* Int+Extension.swift */,
 				2098962728B4DB420011A2F9 /* UIViewController+Extension.swift */,
+				B4CE5B0F28BCAB3F00E3A1D1 /* URLComponents+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -152,6 +183,7 @@
 		B47277CF28AE10CE000075CC /* Error */ = {
 			isa = PBXGroup;
 			children = (
+				B4CE5B0728BCAA4E00E3A1D1 /* APIError.swift */,
 				20534C2B28B4BAA100C5C66C /* FetchingError.swift */,
 				B47277D028AE10DC000075CC /* ParsingError.swift */,
 			);
@@ -165,6 +197,34 @@
 				20DF026A28AB9F63005AA6FA /* DiaryContentsViewController.swift */,
 			);
 			path = Controllers;
+			sourceTree = "<group>";
+		};
+		B4CE5B1B28BCAC5A00E3A1D1 /* WeatherManager */ = {
+			isa = PBXGroup;
+			children = (
+				B4CE5B1928BCABFF00E3A1D1 /* WeatherDataAPIManager.swift */,
+				B45EAB7528B9E6240066F2E8 /* WeatherImageAPIManager.swift */,
+			);
+			path = WeatherManager;
+			sourceTree = "<group>";
+		};
+		B4CE5B1C28BCACC100E3A1D1 /* APIProtocol */ = {
+			isa = PBXGroup;
+			children = (
+				B4CE5B1528BCABB200E3A1D1 /* APIProtocol.swift */,
+				B4CE5B1728BCABD500E3A1D1 /* GETProtocol.swift */,
+			);
+			path = APIProtocol;
+			sourceTree = "<group>";
+		};
+		B4CE5B1D28BCACED00E3A1D1 /* API */ = {
+			isa = PBXGroup;
+			children = (
+				B4CE5B1C28BCACC100E3A1D1 /* APIProtocol */,
+				B4CE5B1328BCAB9B00E3A1D1 /* APIClient.swift */,
+				B4CE5B1128BCAB8200E3A1D1 /* APIConfiguration.swift */,
+			);
+			path = API;
 			sourceTree = "<group>";
 		};
 		C739AE18284DF28600741E8F = {
@@ -268,31 +328,43 @@
 			buildActionMask = 2147483647;
 			files = (
 				C739AE29284DF28600741E8F /* DiaryListViewController.swift in Sources */,
+				B4CE5B1A28BCABFF00E3A1D1 /* WeatherDataAPIManager.swift in Sources */,
 				20DF026528AB769F005AA6FA /* JSONData.swift in Sources */,
 				C739AE25284DF28600741E8F /* AppDelegate.swift in Sources */,
-				20D20EAF28B8A94700A6CACC /* Diary+CoreDataClass.swift in Sources */,
 				202E4EBB28B5E40800AE316D /* DiaryCoreData.swift in Sources */,
 				202E4EC128B5ECD500AE316D /* SearchControllerItem.swift in Sources */,
 				209A338C28AE25AD007C7BB3 /* AssetData.swift in Sources */,
 				209A339028AE3660007C7BB3 /* NavigationItem.swift in Sources */,
 				20534C2C28B4BAA100C5C66C /* FetchingError.swift in Sources */,
 				B47277D128AE10DC000075CC /* ParsingError.swift in Sources */,
+				B4CE5B1628BCABB200E3A1D1 /* APIProtocol.swift in Sources */,
 				20DF026728AB7733005AA6FA /* DiarySampleData.swift in Sources */,
 				20DF026F28ABA780005AA6FA /* Date+Extension.swift in Sources */,
 				C739AE27284DF28600741E8F /* SceneDelegate.swift in Sources */,
+				B4CE5B1228BCAB8200E3A1D1 /* APIConfiguration.swift in Sources */,
+				B45EAB7828B9E7BB0066F2E8 /* WeatherDataEntity.swift in Sources */,
+				B4CE5B0228BC8F1D00E3A1D1 /* Diary+CoreDataProperties.swift in Sources */,
 				2098962828B4DB420011A2F9 /* UIViewController+Extension.swift in Sources */,
 				20DF026D28ABA01A005AA6FA /* DiaryListView.swift in Sources */,
+				B45EAB7628B9E6240066F2E8 /* WeatherImageAPIManager.swift in Sources */,
+				B4CE5B0E28BCAABB00E3A1D1 /* URLComponentsBuilder.swift in Sources */,
+				B4CE5B1828BCABD500E3A1D1 /* GETProtocol.swift in Sources */,
 				20DF026B28AB9F63005AA6FA /* DiaryContentsViewController.swift in Sources */,
 				209A338E28AE35AD007C7BB3 /* Alert.swift in Sources */,
-				20D20EB028B8A94700A6CACC /* Diary+CoreDataProperties.swift in Sources */,
+				B4CE5B0A28BCAA7900E3A1D1 /* HTTPMethod.swift in Sources */,
+				B4CE5B0128BC8F1D00E3A1D1 /* Diary+CoreDataClass.swift in Sources */,
 				20DF026928AB893F005AA6FA /* DiaryListCell.swift in Sources */,
 				C739AE2F284DF28600741E8F /* Diary.xcdatamodeld in Sources */,
+				B4CE5B0828BCAA4E00E3A1D1 /* APIError.swift in Sources */,
 				202E4EBD28B5E75B00AE316D /* ActionSheet.swift in Sources */,
+				B4CE5B1028BCAB3F00E3A1D1 /* URLComponents+Extension.swift in Sources */,
 				20DF027128ABA80A005AA6FA /* DiaryContentView.swift in Sources */,
 				B478312C28AB923100CBB8DA /* Int+Extension.swift in Sources */,
+				B4CE5B0C28BCAA9A00E3A1D1 /* WeatherURLQueryItem.swift in Sources */,
 				202E4EBF28B5EA9000AE316D /* NewLine.swift in Sources */,
 				20534C2A28B4B71400C5C66C /* CoreDataManager.swift in Sources */,
 				B42AD02528ACB226008933E3 /* SystemImage.swift in Sources */,
+				B4CE5B1428BCAB9B00E3A1D1 /* APIClient.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		202516FD28BCEE750047796C /* GPSError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202516FC28BCEE750047796C /* GPSError.swift */; };
 		202E4EBB28B5E40800AE316D /* DiaryCoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202E4EBA28B5E40800AE316D /* DiaryCoreData.swift */; };
 		202E4EBD28B5E75B00AE316D /* ActionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202E4EBC28B5E75B00AE316D /* ActionSheet.swift */; };
 		202E4EBF28B5EA9000AE316D /* NewLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202E4EBE28B5EA9000AE316D /* NewLine.swift */; };
@@ -50,6 +51,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		202516FC28BCEE750047796C /* GPSError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPSError.swift; sourceTree = "<group>"; };
 		202E4EBA28B5E40800AE316D /* DiaryCoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryCoreData.swift; sourceTree = "<group>"; };
 		202E4EBC28B5E75B00AE316D /* ActionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionSheet.swift; sourceTree = "<group>"; };
 		202E4EBE28B5EA9000AE316D /* NewLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewLine.swift; sourceTree = "<group>"; };
@@ -184,6 +186,7 @@
 			isa = PBXGroup;
 			children = (
 				B4CE5B0728BCAA4E00E3A1D1 /* APIError.swift */,
+				202516FC28BCEE750047796C /* GPSError.swift */,
 				20534C2B28B4BAA100C5C66C /* FetchingError.swift */,
 				B47277D028AE10DC000075CC /* ParsingError.swift */,
 			);
@@ -348,6 +351,7 @@
 				20DF026D28ABA01A005AA6FA /* DiaryListView.swift in Sources */,
 				B45EAB7628B9E6240066F2E8 /* WeatherImageAPIManager.swift in Sources */,
 				B4CE5B0E28BCAABB00E3A1D1 /* URLComponentsBuilder.swift in Sources */,
+				202516FD28BCEE750047796C /* GPSError.swift in Sources */,
 				B4CE5B1828BCABD500E3A1D1 /* GETProtocol.swift in Sources */,
 				20DF026B28AB9F63005AA6FA /* DiaryContentsViewController.swift in Sources */,
 				209A338E28AE35AD007C7BB3 /* Alert.swift in Sources */,

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		202E4EC128B5ECD500AE316D /* SearchControllerItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202E4EC028B5ECD500AE316D /* SearchControllerItem.swift */; };
 		20534C2A28B4B71400C5C66C /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20534C2928B4B71400C5C66C /* CoreDataManager.swift */; };
 		20534C2C28B4BAA100C5C66C /* FetchingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20534C2B28B4BAA100C5C66C /* FetchingError.swift */; };
+		20888CA828C0AC96001EF4FD /* Diary+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20888CA628C0AC96001EF4FD /* Diary+CoreDataClass.swift */; };
+		20888CA928C0AC96001EF4FD /* Diary+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20888CA728C0AC96001EF4FD /* Diary+CoreDataProperties.swift */; };
 		2098962828B4DB420011A2F9 /* UIViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2098962728B4DB420011A2F9 /* UIViewController+Extension.swift */; };
 		209A338C28AE25AD007C7BB3 /* AssetData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209A338B28AE25AD007C7BB3 /* AssetData.swift */; };
 		209A338E28AE35AD007C7BB3 /* Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209A338D28AE35AD007C7BB3 /* Alert.swift */; };
@@ -30,8 +32,6 @@
 		B45EAB7828B9E7BB0066F2E8 /* WeatherDataEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45EAB7728B9E7BB0066F2E8 /* WeatherDataEntity.swift */; };
 		B47277D128AE10DC000075CC /* ParsingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47277D028AE10DC000075CC /* ParsingError.swift */; };
 		B478312C28AB923100CBB8DA /* Int+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B478312B28AB923100CBB8DA /* Int+Extension.swift */; };
-		B4CE5B0128BC8F1D00E3A1D1 /* Diary+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CE5AFF28BC8F1D00E3A1D1 /* Diary+CoreDataClass.swift */; };
-		B4CE5B0228BC8F1D00E3A1D1 /* Diary+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CE5B0028BC8F1D00E3A1D1 /* Diary+CoreDataProperties.swift */; };
 		B4CE5B0828BCAA4E00E3A1D1 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CE5B0728BCAA4E00E3A1D1 /* APIError.swift */; };
 		B4CE5B0A28BCAA7900E3A1D1 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CE5B0928BCAA7900E3A1D1 /* HTTPMethod.swift */; };
 		B4CE5B0C28BCAA9A00E3A1D1 /* WeatherURLQueryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CE5B0B28BCAA9A00E3A1D1 /* WeatherURLQueryItem.swift */; };
@@ -39,8 +39,8 @@
 		B4CE5B1028BCAB3F00E3A1D1 /* URLComponents+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CE5B0F28BCAB3F00E3A1D1 /* URLComponents+Extension.swift */; };
 		B4CE5B1228BCAB8200E3A1D1 /* APIConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CE5B1128BCAB8200E3A1D1 /* APIConfiguration.swift */; };
 		B4CE5B1428BCAB9B00E3A1D1 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CE5B1328BCAB9B00E3A1D1 /* APIClient.swift */; };
-		B4CE5B1628BCABB200E3A1D1 /* APIProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CE5B1528BCABB200E3A1D1 /* APIProtocol.swift */; };
-		B4CE5B1828BCABD500E3A1D1 /* GETProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CE5B1728BCABD500E3A1D1 /* GETProtocol.swift */; };
+		B4CE5B1628BCABB200E3A1D1 /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CE5B1528BCABB200E3A1D1 /* API.swift */; };
+		B4CE5B1828BCABD500E3A1D1 /* Getable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CE5B1728BCABD500E3A1D1 /* Getable.swift */; };
 		B4CE5B1A28BCABFF00E3A1D1 /* WeatherDataAPIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CE5B1928BCABFF00E3A1D1 /* WeatherDataAPIManager.swift */; };
 		C739AE25284DF28600741E8F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C739AE24284DF28600741E8F /* AppDelegate.swift */; };
 		C739AE27284DF28600741E8F /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C739AE26284DF28600741E8F /* SceneDelegate.swift */; };
@@ -58,6 +58,8 @@
 		202E4EC028B5ECD500AE316D /* SearchControllerItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchControllerItem.swift; sourceTree = "<group>"; };
 		20534C2928B4B71400C5C66C /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
 		20534C2B28B4BAA100C5C66C /* FetchingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchingError.swift; sourceTree = "<group>"; };
+		20888CA628C0AC96001EF4FD /* Diary+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Diary+CoreDataClass.swift"; sourceTree = "<group>"; };
+		20888CA728C0AC96001EF4FD /* Diary+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Diary+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		2098962728B4DB420011A2F9 /* UIViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
 		209A338B28AE25AD007C7BB3 /* AssetData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetData.swift; sourceTree = "<group>"; };
 		209A338D28AE35AD007C7BB3 /* Alert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Alert.swift; sourceTree = "<group>"; };
@@ -74,8 +76,6 @@
 		B45EAB7728B9E7BB0066F2E8 /* WeatherDataEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherDataEntity.swift; sourceTree = "<group>"; };
 		B47277D028AE10DC000075CC /* ParsingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParsingError.swift; sourceTree = "<group>"; };
 		B478312B28AB923100CBB8DA /* Int+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Extension.swift"; sourceTree = "<group>"; };
-		B4CE5AFF28BC8F1D00E3A1D1 /* Diary+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Diary+CoreDataClass.swift"; sourceTree = "<group>"; };
-		B4CE5B0028BC8F1D00E3A1D1 /* Diary+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Diary+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		B4CE5B0728BCAA4E00E3A1D1 /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
 		B4CE5B0928BCAA7900E3A1D1 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		B4CE5B0B28BCAA9A00E3A1D1 /* WeatherURLQueryItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherURLQueryItem.swift; sourceTree = "<group>"; };
@@ -83,8 +83,8 @@
 		B4CE5B0F28BCAB3F00E3A1D1 /* URLComponents+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLComponents+Extension.swift"; sourceTree = "<group>"; };
 		B4CE5B1128BCAB8200E3A1D1 /* APIConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConfiguration.swift; sourceTree = "<group>"; };
 		B4CE5B1328BCAB9B00E3A1D1 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
-		B4CE5B1528BCABB200E3A1D1 /* APIProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIProtocol.swift; sourceTree = "<group>"; };
-		B4CE5B1728BCABD500E3A1D1 /* GETProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GETProtocol.swift; sourceTree = "<group>"; };
+		B4CE5B1528BCABB200E3A1D1 /* API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
+		B4CE5B1728BCABD500E3A1D1 /* Getable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Getable.swift; sourceTree = "<group>"; };
 		B4CE5B1928BCABFF00E3A1D1 /* WeatherDataAPIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherDataAPIManager.swift; sourceTree = "<group>"; };
 		C739AE21284DF28600741E8F /* Diary.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Diary.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C739AE24284DF28600741E8F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -111,8 +111,8 @@
 			isa = PBXGroup;
 			children = (
 				20534C2928B4B71400C5C66C /* CoreDataManager.swift */,
-				B4CE5AFF28BC8F1D00E3A1D1 /* Diary+CoreDataClass.swift */,
-				B4CE5B0028BC8F1D00E3A1D1 /* Diary+CoreDataProperties.swift */,
+				20888CA628C0AC96001EF4FD /* Diary+CoreDataClass.swift */,
+				20888CA728C0AC96001EF4FD /* Diary+CoreDataProperties.swift */,
 			);
 			path = CoreData;
 			sourceTree = "<group>";
@@ -211,19 +211,19 @@
 			path = WeatherManager;
 			sourceTree = "<group>";
 		};
-		B4CE5B1C28BCACC100E3A1D1 /* APIProtocol */ = {
+		B4CE5B1C28BCACC100E3A1D1 /* Protocol */ = {
 			isa = PBXGroup;
 			children = (
-				B4CE5B1528BCABB200E3A1D1 /* APIProtocol.swift */,
-				B4CE5B1728BCABD500E3A1D1 /* GETProtocol.swift */,
+				B4CE5B1528BCABB200E3A1D1 /* API.swift */,
+				B4CE5B1728BCABD500E3A1D1 /* Getable.swift */,
 			);
-			path = APIProtocol;
+			path = Protocol;
 			sourceTree = "<group>";
 		};
 		B4CE5B1D28BCACED00E3A1D1 /* API */ = {
 			isa = PBXGroup;
 			children = (
-				B4CE5B1C28BCACC100E3A1D1 /* APIProtocol */,
+				B4CE5B1C28BCACC100E3A1D1 /* Protocol */,
 				B4CE5B1328BCAB9B00E3A1D1 /* APIClient.swift */,
 				B4CE5B1128BCAB8200E3A1D1 /* APIConfiguration.swift */,
 			);
@@ -340,27 +340,27 @@
 				209A339028AE3660007C7BB3 /* NavigationItem.swift in Sources */,
 				20534C2C28B4BAA100C5C66C /* FetchingError.swift in Sources */,
 				B47277D128AE10DC000075CC /* ParsingError.swift in Sources */,
-				B4CE5B1628BCABB200E3A1D1 /* APIProtocol.swift in Sources */,
+				B4CE5B1628BCABB200E3A1D1 /* API.swift in Sources */,
 				20DF026728AB7733005AA6FA /* DiarySampleData.swift in Sources */,
 				20DF026F28ABA780005AA6FA /* Date+Extension.swift in Sources */,
 				C739AE27284DF28600741E8F /* SceneDelegate.swift in Sources */,
 				B4CE5B1228BCAB8200E3A1D1 /* APIConfiguration.swift in Sources */,
 				B45EAB7828B9E7BB0066F2E8 /* WeatherDataEntity.swift in Sources */,
-				B4CE5B0228BC8F1D00E3A1D1 /* Diary+CoreDataProperties.swift in Sources */,
 				2098962828B4DB420011A2F9 /* UIViewController+Extension.swift in Sources */,
 				20DF026D28ABA01A005AA6FA /* DiaryListView.swift in Sources */,
 				B45EAB7628B9E6240066F2E8 /* WeatherImageAPIManager.swift in Sources */,
 				B4CE5B0E28BCAABB00E3A1D1 /* URLComponentsBuilder.swift in Sources */,
 				202516FD28BCEE750047796C /* GPSError.swift in Sources */,
-				B4CE5B1828BCABD500E3A1D1 /* GETProtocol.swift in Sources */,
+				20888CA828C0AC96001EF4FD /* Diary+CoreDataClass.swift in Sources */,
+				B4CE5B1828BCABD500E3A1D1 /* Getable.swift in Sources */,
 				20DF026B28AB9F63005AA6FA /* DiaryContentsViewController.swift in Sources */,
 				209A338E28AE35AD007C7BB3 /* Alert.swift in Sources */,
 				B4CE5B0A28BCAA7900E3A1D1 /* HTTPMethod.swift in Sources */,
-				B4CE5B0128BC8F1D00E3A1D1 /* Diary+CoreDataClass.swift in Sources */,
 				20DF026928AB893F005AA6FA /* DiaryListCell.swift in Sources */,
 				C739AE2F284DF28600741E8F /* Diary.xcdatamodeld in Sources */,
 				B4CE5B0828BCAA4E00E3A1D1 /* APIError.swift in Sources */,
 				202E4EBD28B5E75B00AE316D /* ActionSheet.swift in Sources */,
+				20888CA928C0AC96001EF4FD /* Diary+CoreDataProperties.swift in Sources */,
 				B4CE5B1028BCAB3F00E3A1D1 /* URLComponents+Extension.swift in Sources */,
 				20DF027128ABA80A005AA6FA /* DiaryContentView.swift in Sources */,
 				B478312C28AB923100CBB8DA /* Int+Extension.swift in Sources */,

--- a/Diary.xcodeproj/xcshareddata/xcschemes/Diary.xcscheme
+++ b/Diary.xcodeproj/xcshareddata/xcschemes/Diary.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1330"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -50,6 +50,10 @@
             ReferencedContainer = "container:Diary.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <LocationScenarioReference
+         identifier = "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
+         referenceType = "1">
+      </LocationScenarioReference>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Diary/Controllers/DiaryContentsViewController.swift
+++ b/Diary/Controllers/DiaryContentsViewController.swift
@@ -262,28 +262,23 @@ final class DiaryContentsViewController: UIViewController {
     }
     
     private func extractTitleAndBody() -> (String, String)? {
-        guard let diaryConentViewText = diaryContentView.textView.text,
-              diaryConentViewText.contains(NewLine.lineFeed) else {
-            return (diaryContentView.textView.text, DiaryCoreData.emptyBody)
-        }
-        
-        guard diaryContentView.textView.text.isEmpty == false,
-            let lineBreakIndex = diaryConentViewText.firstIndex(of: NewLine.lineFeed)else {
+        guard let diaryConentViewText = diaryContentView.textView.text else {
             return nil
         }
         
-        let firstLineBreakIndex = lineBreakIndex.utf16Offset(in: diaryConentViewText)
+        let splitedText = diaryConentViewText.split(separator: NewLine.lineFeed)
         
-        let titleRange = NSMakeRange(.zero, firstLineBreakIndex)
-        let title = (diaryConentViewText as NSString).substring(with: titleRange)
+        guard let title = splitedText.first else {
+            return nil
+        }
         
-        let bodyRange = NSMakeRange(
-            firstLineBreakIndex + 1,
-            diaryConentViewText.count - title.count - 1
-        )
-        let body = (diaryConentViewText as NSString).substring(with: bodyRange)
-        
-        return (title, body)
+        guard splitedText.count > 1 else {
+            return (String(title), DiaryCoreData.emptyBody)
+        }
+
+        let body = diaryConentViewText[splitedText[1].startIndex...]
+
+        return (String(title), String(body))
     }
     
     private func determineDataProcessingWith(_ title: String, _ body: String, _ creationDate: Date, _ id: UUID, _ main: String, _ icon: String) throws {

--- a/Diary/Controllers/DiaryContentsViewController.swift
+++ b/Diary/Controllers/DiaryContentsViewController.swift
@@ -252,6 +252,8 @@ final class DiaryContentsViewController: UIViewController {
                   let main = main,
                   let icon = icon else {
                 isFetching = false
+                presentErrorAlert(GPSError.noLocation)
+                navigationController?.popViewController(animated: true)
                 return
             }
             

--- a/Diary/Controllers/DiaryContentsViewController.swift
+++ b/Diary/Controllers/DiaryContentsViewController.swift
@@ -73,6 +73,13 @@ final class DiaryContentsViewController: UIViewController {
             target: self,
             action: #selector(sharedAndDeleteButtonTapped)
         )
+        
+        let button = UIButton()
+        button.setImage(SystemImage.leftChevron, for: .normal)
+        button.setTitle(NavigationItem.diaryTitle, for: .normal)
+        button.setTitleColor(.systemBlue, for: .normal)
+        button.addTarget(self, action: #selector(popButtonTapped), for: .allEvents)
+        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: button)
     }
     
     @objc private func sharedAndDeleteButtonTapped() {

--- a/Diary/Controllers/DiaryContentsViewController.swift
+++ b/Diary/Controllers/DiaryContentsViewController.swift
@@ -40,7 +40,9 @@ final class DiaryContentsViewController: UIViewController {
         configureID()
         configureLocationManager()
         
-        locationManager.requestLocation()
+        if locationManager.authorizationStatus == .authorizedWhenInUse {
+            locationManager.requestLocation()
+        }
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -344,6 +346,10 @@ final class DiaryContentsViewController: UIViewController {
 // MARK: - CLLocationManagerDelegate
 
 extension DiaryContentsViewController: CLLocationManagerDelegate {
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        locationManager.requestLocation()
+    }
+    
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         guard let location = locations.first?.coordinate else {
             return
@@ -371,9 +377,10 @@ extension DiaryContentsViewController: CLLocationManagerDelegate {
     }
     
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
-       if let error = error as? CLError, error.code == .denied {
-          
-          return
-       }
+        if let error = error as? CLError, error.code == .denied {
+            
+            presentErrorAlert(GPSError.noAuthorization)
+            return
+        }
     }
 }

--- a/Diary/Controllers/DiaryContentsViewController.swift
+++ b/Diary/Controllers/DiaryContentsViewController.swift
@@ -41,7 +41,6 @@ final class DiaryContentsViewController: UIViewController {
         configureMainAndIcon()
         configureLocationManager()
         
-        locationManager.startUpdatingLocation()
         locationManager.requestLocation()
     }
     
@@ -378,7 +377,7 @@ extension DiaryContentsViewController: CLLocationManagerDelegate {
         
         print(location.latitude)
         print(location.longitude)
-        manager.stopUpdatingLocation()
+        
         
         guard let diary = diary else {
             WeatherDataAPIManager(latitude: location.latitude, longitude: location.longitude)?.requestAndDecodeWeather(dataType: WeatherDataEntity.self)  { result in
@@ -404,7 +403,6 @@ extension DiaryContentsViewController: CLLocationManagerDelegate {
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
        if let error = error as? CLError, error.code == .denied {
           
-          manager.stopUpdatingLocation()
           return
        }
     }

--- a/Diary/Controllers/DiaryContentsViewController.swift
+++ b/Diary/Controllers/DiaryContentsViewController.swift
@@ -249,25 +249,17 @@ final class DiaryContentsViewController: UIViewController {
     }
     
     private func renewCoreData() {
-        if isFetching == false {
-            isFetching = true
+        if !isFetching {
+            isFetching.toggle()
             
             guard let (title, body) = extractTitleAndBody(),
                   let creationDate = creationDate,
                   let id = id else {
-                isFetching = false
+                isFetching.toggle()
                 
                 return
             }
-            
-            guard let main = main,
-                  let icon = icon else {
-                isHavingError = true
-                return
-            }
-            
-            isHavingError = false
-            
+
             do {
                 try determineDataProcessingWith(
                     title: title,
@@ -427,7 +419,7 @@ extension DiaryContentsViewController: CLLocationManagerDelegate {
             WeatherDataAPIManager(
                 latitude: location.latitude,
                 longitude: location.longitude
-            )?.requestAndDecodeWeather(dataType: WeatherDataEntity.self) { [weak self] result in
+            )?.requestWeather(dataType: WeatherDataEntity.self) { [weak self] result in
                 switch result {
                 case .success(let data):
                     DispatchQueue.main.async {

--- a/Diary/Controllers/DiaryContentsViewController.swift
+++ b/Diary/Controllers/DiaryContentsViewController.swift
@@ -383,7 +383,7 @@ extension DiaryContentsViewController: CLLocationManagerDelegate {
     }
     
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        guard let location = locations.first?.coordinate else {
+        guard let location = locations.last?.coordinate else {
             return
         }
         

--- a/Diary/Controllers/DiaryContentsViewController.swift
+++ b/Diary/Controllers/DiaryContentsViewController.swift
@@ -295,12 +295,12 @@ final class DiaryContentsViewController: UIViewController {
         }
         
         guard splitedText.count > 1 else {
-            return (String(title), DiaryCoreData.emptyBody)
+            return (String(title + DiaryCoreData.whiteSpace), DiaryCoreData.emptyBody)
         }
         
         let body = diaryConentViewText[splitedText[1].startIndex...]
         
-        return (String(title), String(body))
+        return (String(title + DiaryCoreData.whiteSpace), String(body))
     }
     
     private func determineDataProcessingWith(

--- a/Diary/Controllers/DiaryContentsViewController.swift
+++ b/Diary/Controllers/DiaryContentsViewController.swift
@@ -20,7 +20,6 @@ final class DiaryContentsViewController: UIViewController {
     private let locationManager = CLLocationManager()
     private var isDeleted: Bool = false
     private var isFetching: Bool = false
-    private var isHavingError: Bool = false
     
     var diary: Diary?
     var isEditingMemo: Bool = false
@@ -90,12 +89,7 @@ final class DiaryContentsViewController: UIViewController {
     
     @objc private func popButtonTapped() {
         renewCoreData()
-        if isHavingError == false {
-            navigationController?.popViewController(animated: true)
-        } else {
-            presentErrorAlert(GPSError.noLocation)
-            isFetching = false
-        }
+        navigationController?.popViewController(animated: true)
     }
     
     private func configureActionSheet() -> UIAlertController {
@@ -438,7 +432,6 @@ extension DiaryContentsViewController: CLLocationManagerDelegate {
                 case .success(let data):
                     DispatchQueue.main.async {
                         self?.presentSuccessAlert()
-                        self?.isHavingError = false
                         self?.isFetching = false
                         
                         guard let firstWeatherData = data.weather.first else {

--- a/Diary/Controllers/DiaryContentsViewController.swift
+++ b/Diary/Controllers/DiaryContentsViewController.swift
@@ -251,7 +251,7 @@ final class DiaryContentsViewController: UIViewController {
                   let id = id,
                   let main = main,
                   let icon = icon else {
-                self.isFetching = false
+                isFetching = false
                 return
             }
             

--- a/Diary/Controllers/DiaryContentsViewController.swift
+++ b/Diary/Controllers/DiaryContentsViewController.swift
@@ -38,7 +38,6 @@ final class DiaryContentsViewController: UIViewController {
         configureNotificationCenter()
         configureCreationDate()
         configureID()
-        configureMainAndIcon()
         configureLocationManager()
         
         locationManager.requestLocation()
@@ -330,31 +329,6 @@ final class DiaryContentsViewController: UIViewController {
         id = diary.id
     }
     
-    private func configureMainAndIcon() {
-        
-//        guard let diary = diary else {
-//            locationManager.requestLocation()
-//
-//            WeatherDataAPIManager(latitude: 37.58677858803961, longitude: 126.99607690004846)?.requestAndDecodeWeather(dataType: WeatherDataEntity.self)  { result in
-//                switch result {
-//                case .success(let data):
-//                    guard let firstWeatherData = data.weather.first else {
-//                        return
-//                    }
-//                    self.main = firstWeatherData.main
-//                    self.icon = firstWeatherData.icon
-//                case .failure(let error):
-//                    self.presentErrorAlert(error)
-//                }
-//            }
-//
-//            return
-//        }
-//
-//        main = diary.main
-//        icon = diary.icon
-    }
-    
     private func showKeyboard() {
         if isEditingMemo == false {
             diaryContentView.textView.becomeFirstResponder()
@@ -374,11 +348,7 @@ extension DiaryContentsViewController: CLLocationManagerDelegate {
         guard let location = locations.first?.coordinate else {
             return
         }
-        
-        print(location.latitude)
-        print(location.longitude)
-        
-        
+
         guard let diary = diary else {
             WeatherDataAPIManager(latitude: location.latitude, longitude: location.longitude)?.requestAndDecodeWeather(dataType: WeatherDataEntity.self)  { result in
                 switch result {

--- a/Diary/Controllers/DiaryListViewController.swift
+++ b/Diary/Controllers/DiaryListViewController.swift
@@ -150,7 +150,7 @@ final class DiaryListViewController: UIViewController {
                 cell.titleLabel.text = item.title
                 cell.dateLabel.text = item.createdAt.localizedString
                 cell.bodyLabel.text = item.body
-                cell.weatherIconImageView.image = item.image
+                cell.weatherIconImageView.image = item.weatherIconImage
                 
                 cell.accessoryType = .disclosureIndicator
                 

--- a/Diary/Controllers/DiaryListViewController.swift
+++ b/Diary/Controllers/DiaryListViewController.swift
@@ -146,9 +146,7 @@ final class DiaryListViewController: UIViewController {
                 cell.titleLabel.text = item.title
                 cell.dateLabel.text = item.createdAt.localizedString
                 cell.bodyLabel.text = item.body
-                if self.iconImages.count > indexPath.row {
-                    cell.weatherIconImageView.image = self.iconImages[indexPath.row]
-                }
+                cell.weatherIconImageView.image = item.image
                 
                 cell.accessoryType = .disclosureIndicator
                 
@@ -280,22 +278,11 @@ extension DiaryListViewController: NSFetchedResultsControllerDelegate {
         
         switch type {
         case .insert:
-            WeatherImageAPIManager(icon: diary.icon)?.requestImage(id: diary.id) { result in
-                switch result {
-                case .success(let image):
-                    self.iconImages.append(image)
-                    DispatchQueue.main.async {
-                        self.diaryView.tableView.reloadData()
-                    }
-                case .failure(let error):
-                    self.presentErrorAlert(error)
-                }
-            }
-            
             guard self.snapshot.numberOfItems != .zero,
                   let newIndexPath = newIndexPath,
                   let lastDiary = self.dataSource?.itemIdentifier(for: newIndexPath) else {
                 self.snapshot.appendItems([diary])
+                dataSource?.apply(snapshot)
                 return
             }
             
@@ -307,6 +294,7 @@ extension DiaryListViewController: NSFetchedResultsControllerDelegate {
         default:
             break
         }
+        dataSource?.apply(snapshot)
     }
 }
 

--- a/Diary/Controllers/DiaryListViewController.swift
+++ b/Diary/Controllers/DiaryListViewController.swift
@@ -39,7 +39,7 @@ final class DiaryListViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         configureNavigationItems()
         registerTableView()
         configureFetchResultsController(from: fetchAllDiaryRequest())
@@ -143,7 +143,7 @@ final class DiaryListViewController: UIViewController {
                 }
                 
                 cell.titleLabel.text = item.title
-                cell.dateLabel.text = item.createdAt?.localizedString
+                cell.dateLabel.text = item.createdAt.localizedString
                 cell.bodyLabel.text = item.body
                 cell.accessoryType = .disclosureIndicator
                 
@@ -201,10 +201,7 @@ extension DiaryListViewController: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         
-        guard let diary = self.dataSource?.itemIdentifier(for: indexPath),
-              let title = diary.title,
-              let body = diary.body,
-              let id = diary.id else {
+        guard let diary = self.dataSource?.itemIdentifier(for: indexPath) else {
             return nil
         }
         
@@ -212,14 +209,14 @@ extension DiaryListViewController: UITableViewDelegate {
             style: .destructive,
             title: ActionSheet.deleteActionTitle
         ) { [weak self] action, view, completion in
-            self?.deleteDiary(using: id)
+            self?.deleteDiary(using: diary.id)
         }
         
         let shareAction = UIContextualAction(
             style: .normal,
             title: ActionSheet.shareActionTitle
         ) { [weak self] action, view, completion in
-            self?.shareDiary(title, body)
+            self?.shareDiary(diary.title, diary.body)
             completion(true)
         }
         

--- a/Diary/Controllers/DiaryListViewController.swift
+++ b/Diary/Controllers/DiaryListViewController.swift
@@ -205,7 +205,7 @@ extension DiaryListViewController: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-        guard let diary = self.dataSource?.itemIdentifier(for: indexPath) else {
+        guard let diary = dataSource?.itemIdentifier(for: indexPath) else {
             return nil
         }
         
@@ -251,7 +251,7 @@ extension DiaryListViewController: UITableViewDelegate {
             activityItems: [title + String(NewLine.lineFeed) + body],
             applicationActivities: nil
         )
-        self.present(activityViewController, animated: true)
+        present(activityViewController, animated: true)
     }
 }
 
@@ -267,7 +267,7 @@ extension DiaryListViewController: NSFetchedResultsControllerDelegate {
         case .insert:
             guard snapshot.numberOfItems != .zero,
                   let newIndexPath = newIndexPath,
-                  let lastDiary = self.dataSource?.itemIdentifier(for: newIndexPath) else {
+                  let lastDiary = dataSource?.itemIdentifier(for: newIndexPath) else {
                 snapshot.appendItems([diary])
                 dataSource?.apply(snapshot)
                 

--- a/Diary/Controllers/DiaryListViewController.swift
+++ b/Diary/Controllers/DiaryListViewController.swift
@@ -29,7 +29,6 @@ final class DiaryListViewController: UIViewController {
         
         return isActive && isSearchBarHasText
     }
-    
     private var iconImages: [UIImage] = []
     
     // MARK: - Life Cycle
@@ -285,19 +284,22 @@ extension DiaryListViewController: NSFetchedResultsControllerDelegate {
                 switch result {
                 case .success(let image):
                     self.iconImages.append(image)
+                    DispatchQueue.main.async {
+                        self.diaryView.tableView.reloadData()
+                    }
                 case .failure(let error):
                     self.presentErrorAlert(error)
                 }
-                
-                guard self.snapshot.numberOfItems != .zero,
-                      let newIndexPath = newIndexPath,
-                      let lastDiary = self.dataSource?.itemIdentifier(for: newIndexPath) else {
-                    self.snapshot.appendItems([diary])
-                    return
-                }
-                
-                self.snapshot.insertItems([diary], beforeItem: lastDiary)
             }
+            
+            guard self.snapshot.numberOfItems != .zero,
+                  let newIndexPath = newIndexPath,
+                  let lastDiary = self.dataSource?.itemIdentifier(for: newIndexPath) else {
+                self.snapshot.appendItems([diary])
+                return
+            }
+            
+            self.snapshot.insertItems([diary], beforeItem: lastDiary)
         case .delete:
             snapshot.deleteItems([diary])
         case .update:

--- a/Diary/Controllers/DiaryListViewController.swift
+++ b/Diary/Controllers/DiaryListViewController.swift
@@ -29,7 +29,6 @@ final class DiaryListViewController: UIViewController {
         
         return isActive && isSearchBarHasText
     }
-    private var iconImages: [UIImage] = []
     
     // MARK: - Life Cycle
     
@@ -54,7 +53,6 @@ final class DiaryListViewController: UIViewController {
         super.viewDidAppear(animated)
         
         navigationController?.navigationBar.sizeToFit()
-        dataSource?.apply(snapshot)
     }
     
     // MARK: - Methods
@@ -114,8 +112,14 @@ final class DiaryListViewController: UIViewController {
     
     private func fetchDiaryRequest(from text: String) -> NSFetchRequest<Diary> {
         let fetchRequest: NSFetchRequest<Diary> = NSFetchRequest(entityName: DiaryCoreData.entityName)
-        let titlePredicate = NSPredicate(format: DiaryCoreData.Predicate.contatingTitle, text)
-        let bodyPredicate = NSPredicate(format: DiaryCoreData.Predicate.containingBody, text)
+        let titlePredicate = NSPredicate(
+            format: DiaryCoreData.Predicate.contatingTitle,
+            text
+        )
+        let bodyPredicate = NSPredicate(
+            format: DiaryCoreData.Predicate.containingBody,
+            text
+        )
         let titleOrBodyPredicate = NSCompoundPredicate(
             type: NSCompoundPredicate.LogicalType.or,
             subpredicates: [titlePredicate, bodyPredicate]
@@ -153,7 +157,6 @@ final class DiaryListViewController: UIViewController {
                 return cell
             }
         )
-        
         dataSource?.apply(snapshot)
     }
     
@@ -163,21 +166,6 @@ final class DiaryListViewController: UIViewController {
             
             guard let diaries = fetchResultsController?.fetchedObjects else {
                 return
-            }
-            
-            diaries.forEach {
-                guard let weatherImageAPIManager = WeatherImageAPIManager(icon: $0.icon) else {
-                    return
-                }
-                
-                weatherImageAPIManager.requestImage(id: $0.id) { result in
-                    switch result {
-                    case .success(let image):
-                        self.iconImages.append(image)
-                    case .failure(let error):
-                        self.presentErrorAlert(error)
-                    }
-                }
             }
             
             snapshot.appendSections([.main])
@@ -210,7 +198,6 @@ extension DiaryListViewController: UITableViewDelegate {
         
         let diary = dataSource?.itemIdentifier(for: indexPath)
         let nextViewController = DiaryContentsViewController()
-        
         nextViewController.diary = diary
         nextViewController.isEditingMemo = true
         
@@ -218,7 +205,6 @@ extension DiaryListViewController: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-        
         guard let diary = self.dataSource?.itemIdentifier(for: indexPath) else {
             return nil
         }
@@ -247,6 +233,7 @@ extension DiaryListViewController: UITableViewDelegate {
             shareAction
         ])
         swipeActionCongifuration.performsFirstActionWithFullSwipe = false
+        
         return swipeActionCongifuration
     }
     
@@ -278,15 +265,16 @@ extension DiaryListViewController: NSFetchedResultsControllerDelegate {
         
         switch type {
         case .insert:
-            guard self.snapshot.numberOfItems != .zero,
+            guard snapshot.numberOfItems != .zero,
                   let newIndexPath = newIndexPath,
                   let lastDiary = self.dataSource?.itemIdentifier(for: newIndexPath) else {
-                self.snapshot.appendItems([diary])
+                snapshot.appendItems([diary])
                 dataSource?.apply(snapshot)
+                
                 return
             }
             
-            self.snapshot.insertItems([diary], beforeItem: lastDiary)
+            snapshot.insertItems([diary], beforeItem: lastDiary)
         case .delete:
             snapshot.deleteItems([diary])
         case .update:
@@ -309,6 +297,7 @@ extension DiaryListViewController: UISearchResultsUpdating {
             configureFetchResultsController(from: fetchAllDiaryRequest())
             configureSnapshot()
             dataSource?.apply(snapshot)
+            
             return
         }
         

--- a/Diary/Controllers/DiaryListViewController.swift
+++ b/Diary/Controllers/DiaryListViewController.swift
@@ -251,6 +251,7 @@ extension DiaryListViewController: UITableViewDelegate {
             activityItems: [title + String(NewLine.lineFeed) + body],
             applicationActivities: nil
         )
+        
         present(activityViewController, animated: true)
     }
 }
@@ -282,6 +283,7 @@ extension DiaryListViewController: NSFetchedResultsControllerDelegate {
         default:
             break
         }
+        
         dataSource?.apply(snapshot)
     }
 }

--- a/Diary/Error/APIError.swift
+++ b/Diary/Error/APIError.swift
@@ -1,0 +1,34 @@
+//
+//  APIError.swift
+//  Diary
+//
+//  Created by Finnn, 수꿍 on 2022/08/29.
+//
+
+import Foundation
+
+enum APIError: Error, LocalizedError {
+    case invalidURL
+    case failedToDecode
+    case failedToConvert
+    case jsonFileNotFound
+    case emptyData
+    case unknownErrorOccured
+    
+    var errorDescription: String {
+        switch self {
+        case .invalidURL:
+            return "URL is not valid."
+        case .failedToDecode:
+            return "Falied to decode response data."
+        case .failedToConvert:
+            return "Failed to convert response data"
+        case .jsonFileNotFound:
+            return "JSON file not found."
+        case .emptyData:
+            return "There is no data."
+        case .unknownErrorOccured:
+            return "Unknown error occured."
+        }
+    }
+}

--- a/Diary/Error/APIError.swift
+++ b/Diary/Error/APIError.swift
@@ -11,7 +11,6 @@ enum APIError: Error, LocalizedError {
     case invalidURL
     case failedToDecode
     case failedToConvert
-    case jsonFileNotFound
     case emptyData
     case unknownErrorOccured
     
@@ -23,8 +22,6 @@ enum APIError: Error, LocalizedError {
             return "Falied to decode response data."
         case .failedToConvert:
             return "Failed to convert response data"
-        case .jsonFileNotFound:
-            return "JSON file not found."
         case .emptyData:
             return "There is no data."
         case .unknownErrorOccured:

--- a/Diary/Error/GPSError.swift
+++ b/Diary/Error/GPSError.swift
@@ -1,0 +1,19 @@
+//
+//  GPSError.swift
+//  Diary
+//
+//  Created by Finnn, 수꿍 on 2022/08/29.
+//
+
+import Foundation
+
+enum GPSError: Error, LocalizedError {
+    case noAuthorization   
+    
+    var errorDescription: String? {
+        switch self {
+        case .noAuthorization:
+            return NSLocalizedString("There is no authorization to fetch GPS", comment: "GPS Error")
+        }
+    }
+}

--- a/Diary/Error/GPSError.swift
+++ b/Diary/Error/GPSError.swift
@@ -8,12 +8,15 @@
 import Foundation
 
 enum GPSError: Error, LocalizedError {
-    case noAuthorization   
+    case noAuthorization
+    case noLocation
     
     var errorDescription: String? {
         switch self {
         case .noAuthorization:
             return NSLocalizedString("There is no authorization to fetch GPS", comment: "GPS Error")
+        case .noLocation:
+            return NSLocalizedString("There is no location data", comment: "Location Error")
         }
     }
 }

--- a/Diary/Extension/UIViewController+Extension.swift
+++ b/Diary/Extension/UIViewController+Extension.swift
@@ -24,4 +24,21 @@ extension UIViewController {
         
         present(errorAlert, animated: true)
     }
+    
+    func presentSuccessAlert() {
+        let successAlert = UIAlertController(
+            title: Alert.successAlertTitle,
+            message: Alert.successAlertMessage,
+            preferredStyle: .alert
+        )
+        
+        let confirmAction = UIAlertAction(
+            title: Alert.confirmActionTitle,
+            style: .default
+        )
+        
+        successAlert.addAction(confirmAction)
+        
+        present(successAlert, animated: true)
+    }
 }

--- a/Diary/Extension/URLComponents+Extension.swift
+++ b/Diary/Extension/URLComponents+Extension.swift
@@ -1,0 +1,26 @@
+//
+//  URLComponents+Extension.swift
+//  Diary
+//
+//  Created by Finnn, 수꿍 on 2022/08/29.
+//
+
+import Foundation
+
+extension URLComponents {
+    mutating func addQuery(_ items: [String: String]) {
+        var newQueryItems = [URLQueryItem]()
+        
+        for (key, value) in items.sorted(by: { $0.key < $1.key }) {
+            newQueryItems.append(URLQueryItem(name: key,
+                                              value: value))
+        }
+        
+        guard queryItems != nil else {
+            queryItems = newQueryItems
+            return
+        }
+        
+        queryItems?.append(contentsOf: newQueryItems)
+    }
+}

--- a/Diary/Models/WeatherDataEntity.swift
+++ b/Diary/Models/WeatherDataEntity.swift
@@ -1,0 +1,15 @@
+//
+//  WeatherDataEntity.swift
+//  Diary
+//
+//  Created by Finnn, 수꿍 on 2022/08/27.
+//
+
+struct Weather: Decodable {
+    let main: String
+    let icon: String
+}
+
+struct WeatherDataEntity: Decodable {
+    let weather: [Weather]
+}

--- a/Diary/Namespaces/Alert.swift
+++ b/Diary/Namespaces/Alert.swift
@@ -8,6 +8,8 @@
 enum Alert {
     static let errorAlertTitle = "Error!"
     static let deleteAlertTitle = "진짜요?"
+    static let successAlertTitle = "성공"
+    static let successAlertMessage = "위치정보를 가져오는데 성공하였습니다!"
     static let deleteAlertMessage = "정말로 삭제하시겠어요?"
     static let deleteActionTitle = "삭제"
     static let cancelActionTitle = "취소"

--- a/Diary/Namespaces/DiaryCoreData.swift
+++ b/Diary/Namespaces/DiaryCoreData.swift
@@ -14,9 +14,9 @@ enum DiaryCoreData {
         static let body = "body"
         static let createdAt = "createdAt"
         static let id = "id"
-        static let main = "main"
-        static let icon = "icon"
-        static let image = "image"
+        static let weatherMainData = "weatherMainData"
+        static let weatherIcon = "weatherIcon"
+        static let weatherIconImage = "weatherIconImage"
     }
     
     enum Predicate {

--- a/Diary/Namespaces/DiaryCoreData.swift
+++ b/Diary/Namespaces/DiaryCoreData.swift
@@ -16,6 +16,7 @@ enum DiaryCoreData {
         static let id = "id"
         static let main = "main"
         static let icon = "icon"
+        static let image = "image"
     }
     
     enum Predicate {

--- a/Diary/Namespaces/DiaryCoreData.swift
+++ b/Diary/Namespaces/DiaryCoreData.swift
@@ -8,6 +8,7 @@
 enum DiaryCoreData {
     static let entityName = "Diary"
     static let emptyBody = ""
+    static let whiteSpace = " "
 
     enum Key {
         static let title = "title"

--- a/Diary/Namespaces/DiaryCoreData.swift
+++ b/Diary/Namespaces/DiaryCoreData.swift
@@ -14,6 +14,8 @@ enum DiaryCoreData {
         static let body = "body"
         static let createdAt = "createdAt"
         static let id = "id"
+        static let main = "main"
+        static let icon = "icon"
     }
     
     enum Predicate {

--- a/Diary/Namespaces/HTTPMethod.swift
+++ b/Diary/Namespaces/HTTPMethod.swift
@@ -1,0 +1,13 @@
+//
+//  HTTPMethod.swift
+//  Diary
+//
+//  Created by Finnn, 수꿍 on 2022/08/29.
+//
+
+enum HTTPMethod {
+    static let get = "GET"
+    static let post = "POST"
+    static let patch = "PATCH"
+    static let delete = "DELETE"
+}

--- a/Diary/Namespaces/SystemImage.swift
+++ b/Diary/Namespaces/SystemImage.swift
@@ -12,4 +12,5 @@ enum SystemImage {
     static let ellipsisCircle = UIImage(systemName: "ellipsis.circle")
     static let trash = UIImage(systemName: "trash.fill")
     static let share = UIImage(systemName: "square.and.arrow.up")
+    static let leftChevron = UIImage(systemName: "chevron.left")
 }

--- a/Diary/Namespaces/WeatherURLQueryItem.swift
+++ b/Diary/Namespaces/WeatherURLQueryItem.swift
@@ -1,0 +1,12 @@
+//
+//  WeatherURLQueryItem.swift
+//  Diary
+//
+//  Created by Finnn, 수꿍 on 2022/08/29.
+//
+
+enum WeatherURLQueryItem {
+    static let latitude = "lat"
+    static let longitude = "lon"
+    static let apiKey = "appid"
+}

--- a/Diary/Resources/API/APIClient.swift
+++ b/Diary/Resources/API/APIClient.swift
@@ -1,0 +1,43 @@
+//
+//  APIClient.swift
+//  Diary
+//
+//  Created by Finnn, 수꿍 on 2022/08/29.
+//
+
+import Foundation
+
+struct APIClient {
+    private var session: URLSession
+    static let shared = APIClient(session: URLSession.shared)
+    
+    private init(session: URLSession = URLSession.shared) {
+        self.session = session
+    }
+    
+    func requestData(with urlRequest: URLRequest,
+                     completion: @escaping (Result<Data, APIError>) -> Void) {
+        session.dataTask(with: urlRequest) { data, response, error in
+            guard error == nil else {
+                completion(.failure(.unknownErrorOccured))
+                
+                return
+            }
+            
+            guard let response = response as? HTTPURLResponse,
+                  (200..<300).contains(response.statusCode) else {
+                completion(.failure(.invalidURL))
+                
+                return
+            }
+            
+            guard let verifiedData = data else {
+                completion(.failure(.emptyData))
+                
+                return
+            }
+            
+            completion(.success(verifiedData))
+        }.resume()
+    }
+}

--- a/Diary/Resources/API/APIConfiguration.swift
+++ b/Diary/Resources/API/APIConfiguration.swift
@@ -1,0 +1,22 @@
+//
+//  APIConfiguration.swift
+//  Diary
+//
+//  Created by Finnn, 수꿍 on 2022/08/29.
+//
+
+import Foundation
+
+struct APIConfiguration {
+    typealias Parameters = [String: String]
+    
+    let url: URL
+    let parameters: Parameters?
+    
+    init(url: URL,
+         parameters: Parameters? = nil) {
+        
+        self.url = url
+        self.parameters = parameters
+    }
+}

--- a/Diary/Resources/API/APIConfiguration.swift
+++ b/Diary/Resources/API/APIConfiguration.swift
@@ -13,8 +13,7 @@ struct APIConfiguration {
     let url: URL
     let parameters: Parameters?
     
-    init(url: URL,
-         parameters: Parameters? = nil) {
+    init(url: URL, parameters: Parameters? = nil) {
         
         self.url = url
         self.parameters = parameters

--- a/Diary/Resources/API/APIProtocol/APIProtocol.swift
+++ b/Diary/Resources/API/APIProtocol/APIProtocol.swift
@@ -1,0 +1,10 @@
+//
+//  APIProtocol.swift
+//  Diary
+//
+//  Created by Finnn, 수꿍 on 2022/08/29.
+//
+
+protocol APIProtocol {
+    var configuration: APIConfiguration { get }
+}

--- a/Diary/Resources/API/APIProtocol/GETProtocol.swift
+++ b/Diary/Resources/API/APIProtocol/GETProtocol.swift
@@ -1,0 +1,65 @@
+//
+//  GETProtocol.swift
+//  Diary
+//
+//  Created by Finnn, 수꿍 on 2022/08/29.
+//
+
+import UIKit
+
+protocol GETProtocol: APIProtocol { }
+
+extension GETProtocol {
+    func requestAndDecodeWeather<T: Decodable>(using client: APIClient = APIClient.shared,
+                                               dataType: T.Type,
+                                               completion: @escaping (Result<T, APIError>) -> Void) {
+        
+        var request = URLRequest(url: configuration.url)
+        request.httpMethod = HTTPMethod.get
+        
+        client.requestData(with: request) { result in
+            switch result {
+            case .success(let data):
+                do {
+                    let decodedData = try JSONDecoder().decode(T.self,
+                                                               from: data)
+                    completion(.success(decodedData))
+                } catch {
+                    completion(.failure(.failedToDecode))
+                }
+            case .failure(_):
+                completion(.failure(.emptyData))
+            }
+        }
+    }
+    
+    func requestImage(using client: APIClient = APIClient.shared,
+                      id: UUID,
+                      completion: @escaping (Result<UIImage, APIError>) -> Void) {
+        let iconImageCache = NSCache<NSString, UIImage>()
+        let id = NSString(string: id.uuidString)
+        
+        if let cachedImage = iconImageCache.object(forKey: id) {
+            completion(.success(cachedImage))
+            
+            return
+        }
+        
+        var request = URLRequest(url: configuration.url)
+        request.httpMethod = HTTPMethod.get
+        
+        client.requestData(with: request) { result in
+            switch result {
+            case .success(let data):
+                guard let image = UIImage(data: data) else {
+                    completion(.failure(.failedToConvert))
+                    return
+                }
+                iconImageCache.setObject(image, forKey: id)
+                completion(.success(image))
+            case .failure(_):
+                completion(.failure(.emptyData))
+            }
+        }
+    }
+}

--- a/Diary/Resources/API/Protocol/API.swift
+++ b/Diary/Resources/API/Protocol/API.swift
@@ -1,10 +1,11 @@
 //
-//  APIProtocol.swift
+//  API.swift
 //  Diary
 //
 //  Created by Finnn, 수꿍 on 2022/08/29.
 //
 
-protocol APIProtocol {
+protocol API {
     var configuration: APIConfiguration { get }
 }
+

--- a/Diary/Resources/API/Protocol/Getable.swift
+++ b/Diary/Resources/API/Protocol/Getable.swift
@@ -1,5 +1,5 @@
 //
-//  GETProtocol.swift
+//  Getable.swift
 //  Diary
 //
 //  Created by Finnn, 수꿍 on 2022/08/29.
@@ -7,10 +7,10 @@
 
 import UIKit
 
-protocol GETProtocol: APIProtocol { }
+protocol Getable: API { }
 
-extension GETProtocol {
-    func requestAndDecodeWeather<T: Decodable>(using client: APIClient = APIClient.shared,
+extension Getable {
+    func requestWeather<T: Decodable>(using client: APIClient = APIClient.shared,
                                                dataType: T.Type,
                                                completion: @escaping (Result<T, APIError>) -> Void) {
         
@@ -27,8 +27,8 @@ extension GETProtocol {
                 } catch {
                     completion(.failure(.failedToDecode))
                 }
-            case .failure(_):
-                completion(.failure(.emptyData))
+            case .failure(let error):
+                completion(.failure(error))
             }
         }
     }
@@ -57,8 +57,8 @@ extension GETProtocol {
                 }
                 iconImageCache.setObject(image, forKey: id)
                 completion(.success(image))
-            case .failure(_):
-                completion(.failure(.emptyData))
+            case .failure(let error):
+                completion(.failure(error))
             }
         }
     }

--- a/Diary/Resources/AppDelegate.swift
+++ b/Diary/Resources/AppDelegate.swift
@@ -10,11 +10,11 @@ import CoreData
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
+    // MARK: UISceneSession Lifecycle
+    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         return true
     }
-
-    // MARK: UISceneSession Lifecycle
 
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
@@ -48,6 +48,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         }
     }
-
 }
-

--- a/Diary/Resources/CoreData/CoreDataManager.swift
+++ b/Diary/Resources/CoreData/CoreDataManager.swift
@@ -30,12 +30,14 @@ final class CoreDataManager {
     
     // MARK: - Methods
 
-    func saveDiary(title: String, body: String, createdAt: Date, id: UUID) throws {
+    func saveDiary(title: String, body: String, createdAt: Date, id: UUID, main: String, icon: String) throws {
         let diary = Diary(context: viewContext)
         diary.setValue(title, forKey: DiaryCoreData.Key.title)
         diary.setValue(body, forKey: DiaryCoreData.Key.body)
         diary.setValue(createdAt, forKey: DiaryCoreData.Key.createdAt)
         diary.setValue(id, forKey: DiaryCoreData.Key.id)
+        diary.setValue(main, forKey: DiaryCoreData.Key.main)
+        diary.setValue(icon, forKey: DiaryCoreData.Key.icon)
 
         if viewContext.hasChanges {
             try viewContext.save()

--- a/Diary/Resources/CoreData/CoreDataManager.swift
+++ b/Diary/Resources/CoreData/CoreDataManager.swift
@@ -30,15 +30,15 @@ final class CoreDataManager {
     
     // MARK: - Methods
 
-    func saveDiary(title: String, body: String, createdAt: Date, id: UUID, main: String, icon: String, image: UIImage) throws {
+    func saveDiary(title: String, body: String, createdAt: Date, id: UUID, weatherMainData: String?, weatherIcon: String?, weatherIconImage: UIImage?) throws {
         let diary = Diary(context: viewContext)
         diary.setValue(title, forKey: DiaryCoreData.Key.title)
         diary.setValue(body, forKey: DiaryCoreData.Key.body)
         diary.setValue(createdAt, forKey: DiaryCoreData.Key.createdAt)
         diary.setValue(id, forKey: DiaryCoreData.Key.id)
-        diary.setValue(main, forKey: DiaryCoreData.Key.main)
-        diary.setValue(icon, forKey: DiaryCoreData.Key.icon)
-        diary.setValue(image, forKey: DiaryCoreData.Key.image)
+        diary.setValue(weatherMainData, forKey: DiaryCoreData.Key.weatherMainData)
+        diary.setValue(weatherIcon, forKey: DiaryCoreData.Key.weatherIcon)
+        diary.setValue(weatherIconImage, forKey: DiaryCoreData.Key.weatherIconImage)
 
         if viewContext.hasChanges {
             try viewContext.save()

--- a/Diary/Resources/CoreData/CoreDataManager.swift
+++ b/Diary/Resources/CoreData/CoreDataManager.swift
@@ -30,7 +30,7 @@ final class CoreDataManager {
     
     // MARK: - Methods
 
-    func saveDiary(title: String, body: String, createdAt: Date, id: UUID, main: String, icon: String) throws {
+    func saveDiary(title: String, body: String, createdAt: Date, id: UUID, main: String, icon: String, image: UIImage) throws {
         let diary = Diary(context: viewContext)
         diary.setValue(title, forKey: DiaryCoreData.Key.title)
         diary.setValue(body, forKey: DiaryCoreData.Key.body)
@@ -38,6 +38,7 @@ final class CoreDataManager {
         diary.setValue(id, forKey: DiaryCoreData.Key.id)
         diary.setValue(main, forKey: DiaryCoreData.Key.main)
         diary.setValue(icon, forKey: DiaryCoreData.Key.icon)
+        diary.setValue(image, forKey: DiaryCoreData.Key.image)
 
         if viewContext.hasChanges {
             try viewContext.save()

--- a/Diary/Resources/CoreData/Diary+CoreDataClass.swift
+++ b/Diary/Resources/CoreData/Diary+CoreDataClass.swift
@@ -2,7 +2,7 @@
 //  Diary+CoreDataClass.swift
 //  Diary
 //
-//  Created by Finnn, 수꿍 on 2022/08/29.
+//  Created by Finnn, 수꿍 on 2022/09/01.
 //
 //
 

--- a/Diary/Resources/CoreData/Diary+CoreDataClass.swift
+++ b/Diary/Resources/CoreData/Diary+CoreDataClass.swift
@@ -2,10 +2,11 @@
 //  Diary+CoreDataClass.swift
 //  Diary
 //
-//  Created by Finnn, 수꿍 on 2022/08/26.
+//  Created by LeeChiheon on 2022/08/29.
 //
 //
 
+import Foundation
 import CoreData
 
 @objc(Diary)

--- a/Diary/Resources/CoreData/Diary+CoreDataClass.swift
+++ b/Diary/Resources/CoreData/Diary+CoreDataClass.swift
@@ -2,11 +2,10 @@
 //  Diary+CoreDataClass.swift
 //  Diary
 //
-//  Created by LeeChiheon on 2022/08/29.
+//  Created by Finnn, 수꿍 on 2022/08/29.
 //
 //
 
-import Foundation
 import CoreData
 
 @objc(Diary)

--- a/Diary/Resources/CoreData/Diary+CoreDataProperties.swift
+++ b/Diary/Resources/CoreData/Diary+CoreDataProperties.swift
@@ -6,7 +6,7 @@
 //
 //
 
-import Foundation
+import UIKit
 import CoreData
 
 
@@ -22,5 +22,6 @@ extension Diary {
     @NSManaged public var id: UUID
     @NSManaged public var main: String
     @NSManaged public var title: String
+    @NSManaged public var image: UIImage
     
 }

--- a/Diary/Resources/CoreData/Diary+CoreDataProperties.swift
+++ b/Diary/Resources/CoreData/Diary+CoreDataProperties.swift
@@ -2,7 +2,7 @@
 //  Diary+CoreDataProperties.swift
 //  Diary
 //
-//  Created by Finnn, 수꿍 on 2022/08/29.
+//  Created by Finnn, 수꿍 on 2022/09/01.
 //
 //
 
@@ -16,9 +16,9 @@ extension Diary {
 
     @NSManaged public var body: String
     @NSManaged public var createdAt: Date
-    @NSManaged public var icon: String
+    @NSManaged public var weatherIcon: String?
     @NSManaged public var id: UUID
-    @NSManaged public var main: String
+    @NSManaged public var weatherIconImage: UIImage?
+    @NSManaged public var weatherMainData: String?
     @NSManaged public var title: String
-    @NSManaged public var image: UIImage
 }

--- a/Diary/Resources/CoreData/Diary+CoreDataProperties.swift
+++ b/Diary/Resources/CoreData/Diary+CoreDataProperties.swift
@@ -2,20 +2,25 @@
 //  Diary+CoreDataProperties.swift
 //  Diary
 //
-//  Created by Finnn, 수꿍 on 2022/08/26.
+//  Created by LeeChiheon on 2022/08/29.
 //
 //
 
+import Foundation
 import CoreData
+
 
 extension Diary {
 
     @nonobjc public class func fetchRequest() -> NSFetchRequest<Diary> {
-        return NSFetchRequest<Diary>(entityName: DiaryCoreData.entityName)
+        return NSFetchRequest<Diary>(entityName: "Diary")
     }
 
-    @NSManaged public var body: String?
-    @NSManaged public var createdAt: Date?
-    @NSManaged public var title: String?
-    @NSManaged public var id: UUID?
+    @NSManaged public var body: String
+    @NSManaged public var createdAt: Date
+    @NSManaged public var icon: String
+    @NSManaged public var id: UUID
+    @NSManaged public var main: String
+    @NSManaged public var title: String
+    
 }

--- a/Diary/Resources/CoreData/Diary+CoreDataProperties.swift
+++ b/Diary/Resources/CoreData/Diary+CoreDataProperties.swift
@@ -2,16 +2,14 @@
 //  Diary+CoreDataProperties.swift
 //  Diary
 //
-//  Created by LeeChiheon on 2022/08/29.
+//  Created by Finnn, 수꿍 on 2022/08/29.
 //
 //
 
 import UIKit
 import CoreData
 
-
 extension Diary {
-
     @nonobjc public class func fetchRequest() -> NSFetchRequest<Diary> {
         return NSFetchRequest<Diary>(entityName: "Diary")
     }
@@ -23,5 +21,4 @@ extension Diary {
     @NSManaged public var main: String
     @NSManaged public var title: String
     @NSManaged public var image: UIImage
-    
 }

--- a/Diary/Resources/Diary.xcdatamodeld/Diary.xcdatamodel/contents
+++ b/Diary/Resources/Diary.xcdatamodeld/Diary.xcdatamodel/contents
@@ -5,10 +5,11 @@
         <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="icon" attributeType="String"/>
         <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="image" attributeType="Transformable" valueTransformerName="" customClassName="UIImage"/>
         <attribute name="main" attributeType="String"/>
         <attribute name="title" attributeType="String"/>
     </entity>
     <elements>
-        <element name="Diary" positionX="-63" positionY="-18" width="128" height="119"/>
+        <element name="Diary" positionX="-63" positionY="-18" width="128" height="134"/>
     </elements>
 </model>

--- a/Diary/Resources/Diary.xcdatamodeld/Diary.xcdatamodel/contents
+++ b/Diary/Resources/Diary.xcdatamodeld/Diary.xcdatamodel/contents
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="20086" systemVersion="21F79" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="20086" systemVersion="21G72" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Diary" representedClassName="Diary" syncable="YES">
         <attribute name="body" attributeType="String"/>
         <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="icon" attributeType="String"/>
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="main" attributeType="String"/>
         <attribute name="title" attributeType="String"/>
     </entity>
     <elements>
-        <element name="Diary" positionX="-63" positionY="-18" width="128" height="89"/>
+        <element name="Diary" positionX="-63" positionY="-18" width="128" height="119"/>
     </elements>
 </model>

--- a/Diary/Resources/Diary.xcdatamodeld/Diary.xcdatamodel/contents
+++ b/Diary/Resources/Diary.xcdatamodeld/Diary.xcdatamodel/contents
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="20086" systemVersion="21G72" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="20086" systemVersion="21F79" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Diary" representedClassName="Diary" syncable="YES">
         <attribute name="body" attributeType="String"/>
         <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="icon" attributeType="String"/>
         <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
-        <attribute name="image" attributeType="Transformable" valueTransformerName="" customClassName="UIImage"/>
-        <attribute name="main" attributeType="String"/>
         <attribute name="title" attributeType="String"/>
+        <attribute name="weatherIcon" optional="YES" attributeType="String"/>
+        <attribute name="weatherIconImage" optional="YES" attributeType="Transformable" valueTransformerName="" customClassName="UIImage"/>
+        <attribute name="weatherMainData" optional="YES" attributeType="String"/>
     </entity>
     <elements>
         <element name="Diary" positionX="-63" positionY="-18" width="128" height="134"/>

--- a/Diary/Resources/Info.plist
+++ b/Diary/Resources/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>날씨 정보를 추적하기 위하여 사용자 위치를 사용합니다.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Diary/Resources/URLComponentsBuilder.swift
+++ b/Diary/Resources/URLComponentsBuilder.swift
@@ -1,0 +1,42 @@
+//
+//  URLComponentsBuilder.swift
+//  Diary
+//
+//  Created by Finnn, 수꿍 on 2022/08/29.
+//
+
+import Foundation
+
+final class URLComponentsBuilder {
+    private var urlComponents = URLComponents()
+    
+    init() { }
+    
+    func build() -> URLComponents {
+        return urlComponents
+    }
+    
+    func setScheme(_ scheme: String) -> URLComponentsBuilder {
+        urlComponents.scheme = scheme
+        
+        return self
+    }
+    
+    func setHost(_ host: String) -> URLComponentsBuilder {
+        urlComponents.host = host
+        
+        return self
+    }
+    
+    func setPath(_ path: String) -> URLComponentsBuilder {
+        urlComponents.path = path
+        
+        return self
+    }
+    
+    func addQuery(items: [String: String]) -> URLComponentsBuilder {
+        urlComponents.addQuery(items)
+        
+        return self
+    }
+}

--- a/Diary/Resources/URLComponentsBuilder.swift
+++ b/Diary/Resources/URLComponentsBuilder.swift
@@ -10,8 +10,6 @@ import Foundation
 final class URLComponentsBuilder {
     private var urlComponents = URLComponents()
     
-    init() { }
-    
     func build() -> URLComponents {
         return urlComponents
     }

--- a/Diary/Resources/WeatherManager/WeatherDataAPIManager.swift
+++ b/Diary/Resources/WeatherManager/WeatherDataAPIManager.swift
@@ -1,0 +1,30 @@
+//
+//  WeatherDataAPIManager.swift
+//  Diary
+//
+//  Created by Finnn, 수꿍 on 2022/08/29.
+//
+
+import Foundation
+
+struct WeatherDataAPIManager: GETProtocol {
+    var configuration: APIConfiguration
+    var urlComponents: URLComponents
+    
+    init?(latitude: Double, longitude: Double) {
+        urlComponents = URLComponentsBuilder()
+            .setScheme("https")
+            .setHost("api.openweathermap.org")
+            .setPath("/data/2.5/weather")
+            .addQuery(items: [WeatherURLQueryItem.latitude: "\(latitude)",
+                              WeatherURLQueryItem.longitude: "\(longitude)",
+                              WeatherURLQueryItem.apiKey: "16592fac87216b6b99b42948875396e6"])
+            .build()
+        
+        guard let url = urlComponents.url else {
+            return nil
+        }
+        
+        configuration = APIConfiguration(url: url)
+    }
+}

--- a/Diary/Resources/WeatherManager/WeatherDataAPIManager.swift
+++ b/Diary/Resources/WeatherManager/WeatherDataAPIManager.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct WeatherDataAPIManager: GETProtocol {
+struct WeatherDataAPIManager: Getable {
     var configuration: APIConfiguration
     var urlComponents: URLComponents
     

--- a/Diary/Resources/WeatherManager/WeatherImageAPIManager.swift
+++ b/Diary/Resources/WeatherManager/WeatherImageAPIManager.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct WeatherImageAPIManager: GETProtocol {
+struct WeatherImageAPIManager: Getable {
     var configuration: APIConfiguration
     var urlComponents: URLComponents
     

--- a/Diary/Resources/WeatherManager/WeatherImageAPIManager.swift
+++ b/Diary/Resources/WeatherManager/WeatherImageAPIManager.swift
@@ -1,0 +1,27 @@
+//
+//  WeatherManager.swift
+//  Diary
+//
+//  Created by Finnn, 수꿍 on 2022/08/27.
+//
+
+import Foundation
+
+struct WeatherImageAPIManager: GETProtocol {
+    var configuration: APIConfiguration
+    var urlComponents: URLComponents
+    
+    init?(icon: String) {
+        urlComponents = URLComponentsBuilder()
+            .setScheme("https")
+            .setHost("openweathermap.org")
+            .setPath("/img/wn/\(icon)@4x.png")
+            .build()
+        
+        guard let url = urlComponents.url else {
+            return nil
+        }
+        
+        configuration = APIConfiguration(url: url)
+    }
+}

--- a/Diary/Views/DiaryListCell.swift
+++ b/Diary/Views/DiaryListCell.swift
@@ -37,6 +37,13 @@ final class DiaryListCell: UITableViewCell {
         return label
     }()
     
+    let weatherIconImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        
+        return imageView
+    }()
+    
     let bodyLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -52,7 +59,7 @@ final class DiaryListCell: UITableViewCell {
         stackView.axis = .horizontal
         stackView.distribution = .fill
         stackView.alignment = .fill
-        stackView.spacing = 10
+        stackView.spacing = 8
         
         return stackView
     }()
@@ -79,7 +86,13 @@ final class DiaryListCell: UITableViewCell {
         contentView.addSubview(stackView)
         
         stackView.addArrangedSubview(dateLabel)
+        stackView.addArrangedSubview(weatherIconImageView)
         stackView.addArrangedSubview(bodyLabel)
+        
+        NSLayoutConstraint.activate([
+            weatherIconImageView.heightAnchor.constraint(equalToConstant: 28),
+            weatherIconImageView.widthAnchor.constraint(equalTo: weatherIconImageView.heightAnchor)
+        ])
         
         NSLayoutConstraint.activate([
             titleLabel.topAnchor.constraint(

--- a/Diary/Views/DiaryListCell.swift
+++ b/Diary/Views/DiaryListCell.swift
@@ -91,10 +91,8 @@ final class DiaryListCell: UITableViewCell {
         
         NSLayoutConstraint.activate([
             weatherIconImageView.heightAnchor.constraint(equalToConstant: 28),
-            weatherIconImageView.widthAnchor.constraint(equalTo: weatherIconImageView.heightAnchor)
-        ])
-        
-        NSLayoutConstraint.activate([
+            weatherIconImageView.widthAnchor.constraint(equalTo: weatherIconImageView.heightAnchor),
+
             titleLabel.topAnchor.constraint(
                 equalTo: contentView.topAnchor,
                 constant: 10

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 ### Week 1
     
-> 2022.08.16 ~ 2022.08.17
+> 2022.08.16 ~ 2022.08.19
     
 - 2022.08.16
     - 간단한 자기소개
@@ -77,6 +77,31 @@
     - 전반적인 컨벤션 수정 및 리팩토링
     - `STEP 2 PR` 작성
     
+- 2022.08.25
+    - 검색시 `SearchBar` 색상 오류 수정
+    - `ViewContext` 커스텀으로 처리
+    - `fetch` 방식을 `UUID`로 변경
+    
+- 2022.08.26
+    - `body`가 없을 경우 저장되지 않았던 문제 수정
+    - 스크롤시 `searchBar`가 숨겨지도록 변경
+    
+### Week 3
+
+> 2022.08.29 ~ 2022.08.30
+    
+- 2022.08.29
+    - `OpenWeatherAPI` `fetching`을 위한 `DataType` 정의
+    - `Weather` 데이터 처리를 위한 `Manager` 타입 정의
+    - `CoreData`에 날씨 정보 `Attributes` 추가
+    
+- 2022.08.30
+    - `CoreLocation`을 통해 사용자에게 위치 정보 요청
+    - 위치 정보를 기반으로 `Weather` 데이터 다운로드
+    - 날씨 아이콘을 각 셀에 적용
+    - 전반적인 컨벤션 수정 및 리팩토링
+    - `STEP 3 PR` 작성
+    
 ## 💡 키워드
 
 - `JSONDecoder`, `NSDataAsset`, `Parsing`
@@ -97,6 +122,9 @@
 - `NSMutableAttributedString`, `firstIndex`, `utf16Offset`, `NSMakeRange`, `substring`
 - `Notification`, `willResignActiveNotification`
 - `Tuple`
+- `Core Location`, `CLLocationManagerDelegate`, `CLLocationManager`, `authorizationStatus`
+- `requestLocation`, `CLLocation`, `coordinate`, `latitude`, `longitude`
+- `Open API`, `Networking`
 
     
 ## 🤔 핵심경험
@@ -106,6 +134,8 @@
 - [x] 코어데이터 모델 생성
 - [x] 코어데이터 모델 및 DB 마이그레이션
 - [x] 테이블뷰에서 스와이프를 통한 삭제기능 구현
+- [x] Open API의 활용
+- [x] Core Location의 활용
 
 ## 🗂 폴더 구조
 
@@ -115,30 +145,38 @@
 │   ├── Controllers
 │   │   ├── DiaryContentsViewController.swift
 │   │   └── DiaryListViewController.swift
-│   ├── CoreData
-│   │   ├── Diary+CoreDataClass.swift
-│   │   └── Diary+CoreDataProperties.swift
 │   ├── Error
+│   │   ├── APIError.swift
 │   │   ├── FetchingError.swift
+│   │   ├── GPSError.swift
 │   │   └── ParsingError.swift
 │   ├── Extension
 │   │   ├── Date+Extension.swift
 │   │   ├── Int+Extension.swift
-│   │   └── UIViewController+Extension.swift
+│   │   ├── UIViewController+Extension.swift
+│   │   └── URLComponents+Extension.swift
 │   ├── Models
-│   │   ├── CoreDataManager.swift
 │   │   ├── DiarySampleData.swift
-│   │   └── JSONData.swift
+│   │   ├── JSONData.swift
+│   │   └── WeatherDataEntity.swift
 │   ├── Namespaces
 │   │   ├── ActionSheet.swift
 │   │   ├── Alert.swift
 │   │   ├── AssetData.swift
 │   │   ├── DiaryCoreData.swift
+│   │   ├── HTTPMethod.swift
 │   │   ├── NavigationItem.swift
 │   │   ├── NewLine.swift
 │   │   ├── SearchControllerItem.swift
-│   │   └── SystemImage.swift
+│   │   ├── SystemImage.swift
+│   │   └── WeatherURLQueryItem.swift
 │   ├── Resources
+│   │   ├── API
+│   │   │   ├── APIClient.swift
+│   │   │   ├── APIConfiguration.swift
+│   │   │   └── APIProtocol
+│   │   │       ├── APIProtocol.swift
+│   │   │       └── GETProtocol.swift
 │   │   ├── AppDelegate.swift
 │   │   ├── Assets.xcassets
 │   │   │   ├── AccentColor.colorset
@@ -151,11 +189,19 @@
 │   │   │       └── sample.json
 │   │   ├── Base.lproj
 │   │   │   └── LaunchScreen.storyboard
+│   │   ├── CoreData
+│   │   │   ├── CoreDataManager.swift
+│   │   │   ├── Diary+CoreDataClass.swift
+│   │   │   └── Diary+CoreDataProperties.swift
 │   │   ├── Diary.xcdatamodeld
 │   │   │   └── Diary.xcdatamodel
 │   │   │       └── contents
 │   │   ├── Info.plist
-│   │   └── SceneDelegate.swift
+│   │   ├── SceneDelegate.swift
+│   │   ├── URLComponentsBuilder.swift
+│   │   └── WeatherManager
+│   │       ├── WeatherDataAPIManager.swift
+│   │       └── WeatherImageAPIManager.swift
 │   └── Views
 │       ├── DiaryContentView.swift
 │       ├── DiaryListCell.swift
@@ -180,7 +226,7 @@
     - UITextView를 활용한 메모 작성 페이지 구현
     - UITextView에 내용 작성시 소프트웨어 키보드가 작성중인 글을 가리지 않도록 수정
     
-### STEP 2    
+### STEP 2
 
 **각 Cell을 터치 할 경우 해당 메모를 불러오는 기능**
     
@@ -214,7 +260,16 @@
         - 원하는 일기 검색 시, `title`과 `body`에 해당 내용이 포함되어 있는 일기만을 `Core Data`에서 `fetch`
         - 일기 검색 초기화 시, 다시 모든 일기를 `Core Data`에서 `fetch`
 
-
+### STEP 3
+    
+**현재 사용자의 위치(Core Location)를 기반으로 현재 날씨정보(Open Weather API) 가져오기**
+    
+    - Open Weather API 데이터를 fetch해오는 WeatherDataAPIManager 정의
+    - CLLocationManager 인스턴스를 생성하여 requestLocation 메서드 호출
+    - CLLocationManagerDelegate 프로토콜을 통한 Location 업데이트 시
+        - WeatherDataAPIManager를 통해 Weather Data 가져오기
+        - diary의 main, icon 프로퍼티 할당
+    
 
 ## 🚀 TroubleShooting
 
@@ -375,6 +430,35 @@ private func configureDataSource() {
 }
 ```
     
+### STEP 3
+#### T1. 일기의 `Title`과 `Body` 구분 로직
+- `Title`과 `Body`를 구분하는 이전 로직을 검토해본 결과, `Body`가 없이 `Title`로만 일기를 구성하였을 때도, 일기가 저장되는 것이 옳은 일기장 어플리케이션 구현이라고 판단하였습니다. 이러한 생각을 바탕으로, 로직을 수정하던 중, `Body`의 경우 개행이 2번된 경우, 일기장 리스트 화면에서 `Body`의 내용물이 아닌, 개행으로 인한 빈 내용이 표시되는 문제가 발생하였습니다.
+    
+- 이를 해결하기 위하여 다음과 같이 코드를 수정해보았습니다. 먼저, `diaryContentView` 내 `textView`의 `text`를 옵셔널 바인딩 후, 개행을 기준으로 `split`을 진행하였습니다. 그리고 `split`된 문자열 배열의 첫번째 구성요소는 `title`에 해당할 것이므로, `title`에 담았고, `title` 값이 없을시, `textView`의 값은 유의미한 글자가 없는 값이므로 `nil` 처리를 하여 일기를 `save`하지 않도록 처리하였습니다. 그리고 만일 `splitText`의 `count`가 1보다 크지 않으면, 선행 조건에서 이어진 경우이기에, `count`가 1인 경우이므로, `title`만 있는 경우이기에 `(String(title), DiaryCoreData.emptyBody)`로 타이틀과 빈 바디를 반환하였습니다. 그리고 전체 `diaryConentViewText`에서 `body`가 시작되는 인덱스부터를 범위로 삼아 `body`를 추출하였습니다.
+
+- 코드
+```swift
+private func extractTitleAndBody() -> (String, String)? {
+    guard let diaryConentViewText = diaryContentView.textView.text else {
+        return nil
+    }
+    
+    let splitedText = diaryConentViewText.split(separator: NewLine.lineFeed)
+    
+    guard let title = splitedText.first else {
+        return nil
+    }
+    
+    guard splitedText.count > 1 else {
+        return (String(title), DiaryCoreData.emptyBody)
+    }
+    
+    let body = diaryConentViewText[splitedText[1].startIndex...]
+    
+    return (String(title), String(body))
+}
+```
+    
     
 ## 📚 참고문서
 
@@ -388,7 +472,15 @@ private func configureDataSource() {
 - [Making Apps with Core Data](https://developer.apple.com/videos/play/wwdc2019/230/)
 - [UITextViewDelegate](https://developer.apple.com/documentation/uikit/uitextviewdelegate)
 - [UISwipeActionsConfiguration](https://developer.apple.com/documentation/uikit/uiswipeactionsconfiguration)
+- [Dynamic Type Sizes](https://developer.apple.com/design/human-interface-guidelines/foundations/typography/)
+- [Open Weather - Current weather data](https://openweathermap.org/current)
+- [Core Location](https://developer.apple.com/documentation/corelocation)
+    - [Getting the User’s Location](https://developer.apple.com/documentation/corelocation/getting_the_user_s_location)
+    - [Adding Location Services to Your App](https://developer.apple.com/documentation/corelocation/adding_location_services_to_your_app)
+    - [Requesting Authorization for Location Services](https://developer.apple.com/documentation/corelocation/requesting_authorization_for_location_services)
+- [Using Lightweight Migration](https://developer.apple.com/documentation/coredata/using_lightweight_migration)
 
+    
 --- 
     
 ## 1️⃣ STEP 1
@@ -444,6 +536,10 @@ private func configureDataSource() {
     
 - 이에 저희는 `TableView`를 활용할 때는, `NSFetchResultsController`를 사용하는 것이 더욱 편리하다고 생각하여 이를 이번 프로젝트에 적용해보았습니다. 현업에서는 코어 데이터를 사용할 때, `NSFetchResultsController`를 적극적으로 사용하는지 여쭈어보고 싶습니다.
 
+#### A1. NSFetchResultsController 메서드 현업 사용 여부
+    
+- 현업에서 사용 여부를 물어보시면 두괄식으로 먼저 말씀드리면 조건이 있는 예쓰였다. 지금처럼 로컬 DB를 활용해야 하는 경우에서 `CoreData`를 사용한다고 치면 지금 같은 상황에서는 이미 잘 만들어놓은 `NSFetchResultsController`라는 `API`를 사용하지 않을 이유가 없다고 한다. 그 이유는 이번 스텝2를 진행하며 느꼈던 장점이 답이 될 수 있다. 그럼 왜 조건이 있는 예쓰라고 했는지 의문이 들 수 있다. 거기에 대한 대답은 일단 당연히 이건 모든 조직마다 현업마다 다르겠지만 그린의 경우 `CoreData` 대신 주로 `Realm`이라는 라이브러리를 사용한다고 한다. `Realm`을 사용하면 좀 더 편리하고 직관적으로 사용할 수 있다고 한다. 그렇기에 현업에서 `CoreData`를 사용한다면 `NSFetchResultsController`를 상황에 맞게 활용하겠지만 애초에 다른 로컬 `DB` 라이브러리를 활용한다면 사용하지 않을 것이다. 
+    
 #### Q2. `appDelegate.persistentContainer.viewContext.save()` vs `appDelegate.saveContext()`
 - `CoreData`를 처리할 때 처음에는 `persistentContainer` 내부에 있는 `viewContext.save()`를 통해 직접 저장을 처리하고, 그에 따른 에러를 처리했었습니다.
 - 그런데 `CoreData`를 생성할 때 `AppDelegate.swift` 파일 내부에 `appDelegate.saveContext()`라는 메서드가 기본적으로 생성된다는 것을 깨닫고, 애플에서 기본적으로 만들주는 코드이기 때문에 사용하는 것이 좋지 않을까 하는 생각에 해당 메서드를 통해 `CoreData`에 데이터가 저장이 되도록 처리했습니다.
@@ -468,9 +564,13 @@ func saveContext() {
 
 - 애플에서 기본적으로 제공해주고 있는 `saveContext()` 메서드를 사용해서 처리하는 것이 좋을지, 아니면 직접 `context.save()`를 호출해서 데이터 저장 후, 에러를 별도로 직접 처리해주는 것이 좋은지 궁금합니다! 🙏
     
+#### A2. `appDelegate.persistentContainer.viewContext.save()` vs `appDelegate.saveContext()`
+    
+- 그린의 경우 가령 이 부분 뿐만 아니라 최대한 커스텀하게 처리해주는걸 선호한다고 리뷰해주었다. 이유는 에러 처리를 명확하게 우리가 원하는 방식으로 해주는게 더 적절하다고 생각하기 때문이었다. fatalError 자체는 기본적으로 애플에서 흔히 뭐 없을때 그냥 작성한 느낌으로 사용될 때가 많다고 한다. 사실 앱 크래쉬를 내지 않아도 되는것인데도 약간 관습처럼 넣는 경우가 많다. 그렇기에 애플의 기본 API를 그렇게 많이 신뢰하면서 따르지는 않는다 한다. 그렇기에 답은 직접 필요한 메서드를 호출해 fatalError 대신 원하는 방식에 맞게 에러를 별도로 처리해주는 방법이 더 적절하다고 생각한다.
+    
 #### Q3. 튜플 조건문 가독성 향상 고민 
 
-- `fetchSuccess` 상수의 경우, 해당 일기가 이미 일전에 작성한 일기인지 확인하기 위한 Diary 타입의 값이고, `isDeleted` 변수의 경우 액션시트를 통해 삭제 기능이 요청되어 있는지 판단하기 위한 `Bool` 값입니다. 처음에는 이를 `guard`를 통해 분기를 하려고 했지만, `else` 케이스 안에 또 `guard`문을 필요로하여, `switch`문을 이용하면 분기를 좀 더 간결하게 표현할 수 있었습니다.
+- `fetchSuccess` 상수의 경우, 해당 일기가 이미 일전에 작성한 일기인지 확인하기 위한 `Diary` 타입의 값이고, `isDeleted` 변수의 경우 액션시트를 통해 삭제 기능이 요청되어 있는지 판단하기 위한 `Bool` 값입니다. 처음에는 이를 `guard`를 통해 분기를 하려고 했지만, `else` 케이스 안에 또 `guard`문을 필요로하여, `switch`문을 이용하면 분기를 좀 더 간결하게 표현할 수 있었습니다.
     
 - 다만, 튜플 값을 이용하여 switch 문을 사용하다보니 (nil, false), (_, false) case와 같이 한눈에 어떤 경우인지 파악하기는 힘들 것 같다는 생각이 들었습니다. 이를 좀 더 가독성 좋게 표현하기 위해서는 어떤 방법을 활용하면 좋을지 조언을 구하고 싶습니다! 
     
@@ -498,6 +598,10 @@ private func determineDataProcessingFor(_ title: String, _ body: String, _ creat
     }
 ```
     
+#### A3. 튜플 조건문 가독성 향상 고민     
+
+- 현재 작성한 튜플 조건문의 가독성은 특별한 문제가 없는 상태로 다시 판단되어, 별다른 수정을 진행하지 않았다.
+
 #### Q4. UISearchController 내부의 obscuresBackgroundDuringPresentation 프로퍼티 사용시 정상적으로 나타나지 않는 문제
 - `UISearchController` 내부의 `obscuresBackgroundDuringPresentation` 프로퍼티를 true로 설정할 경우 아래의 사진처럼 나와야 하는 것으로 알고 있었습니다.
 
@@ -531,5 +635,102 @@ private func configureSearchController() {
     searchController.searchBar.placeholder = SearchControllerItem.placeHolder
     navigationItem.searchController = searchController
     navigationItem.hidesSearchBarWhenScrolling = false
+}
+```
+
+#### A4. UISearchController 내부의 obscuresBackgroundDuringPresentation 프로퍼티 사용시 정상적으로 나타나지 않는 문제
+    
+- `obscuresBackgroundDuringPresentation = true` 설정은 백그라운드 그러니까 해당 서치바까지 감싸져 있는 배경에 적용된다. 즉 아래처럼 뷰 디버깅을 해보면 서치바가 올려져 있는 배경 전체가 딤드된걸 볼 수 있다.
+
+- 이미지
+    
+    ![Untitled 2](https://user-images.githubusercontent.com/99063327/186930966-827574d7-264f-48a9-9c2b-cc139068b23d.png)
+    
+
+- 그렇기에 저 설정이 서치바는 그대로 흰색인데 그 밑에 리스트만 자동으로 구현해주는건 아닐것 같고, 우리가 원하는 예시는 별도 처리가 더 이뤄져 있을 것이다. 
+
+- 현재 서치바나 특정 네비게이션 부분의 background 색상을 특별히 지정해주지 않았기에 시스템을 따라간 것이다. 즉 이것들이 올려진 백그라운드를 따라간 것이 된다. 그렇기에 우리가 구상한 검색창을 구현하기 위해서는처리를 원하는 컴포넌트들에 기본 색상을 지정해줘야 한다. 아래의 코드를 통하여 단순히 서치바 구성 시 서치바의 백그라운드 색상을 white로 지정해주면 해결이 되는 간단한 문제였다.
+
+
+- 코드
+```swift
+searchController.obscuresBackgroundDuringPresentation = true
+searchController.searchBar.backgroundColor = .white
+```
+    
+## 3️⃣ STEP 3
+    
+### STEP 3 Questions & Answers
+
+#### Q1. 시뮬레이터에서 Location 변경시 정상적으로 적용되지 않는 문제
+- 이번 프로젝트를 진행하면서 `CoreLocation`으로 사용자에게 위치 정보를 받아오는 요구사항이 있었습니다.
+- 위치가 제대로 들어가는지 확인하기 위해서 `Simulator`에서 `location`을 변경해봤지만, 변경된 위치가 들어가지 않고, 이 전에 설정했던 위치가 계속 들어갔습니다.
+- 그런데 정말 이상하게도 아이폰 기본 지도 앱을 한번 실행한 후 다시 테스트를 했을때는 `Location`을 변경해줬을때 바로바로 적용이 되었습니다.
+
+![](https://i.imgur.com/oAmI4Ea.png)
+
+![](https://i.imgur.com/QxV7koj.png)
+
+- ⬆️ 해당 메뉴에서 위치를 변경해도 `Simulator`에서는 바로 적용되지 않는 문제가 발생했습니다.
+- 단순히 애플 기본 지도 앱을 실행 후 종료해주는 것 만으로 해결되었습니다.
+- 올바른 해결방법이 아니라는 생각이 들어 혹시 원인을 아시는지 궁금합니다 🤔
+    
+#### Q2. 서버에서 데이터를 받아오고 있는 중인지 체크하는 법
+- save 기능이 구현된 메서드가 호출되면 `Weather` 아이콘을 인터넷에서 받아오고 있습니다.
+- 하지만 이전 프로젝트 구현 사항으로 일기장의 저장 경우의 수는 일기장 목록으로 되돌아갈 때, 백그라운드에 들어갈 때, 키보드가 내려갈 때로, 총 3가지 경우입니다.
+- 그런데 일기장 목록으로 되돌아가면 이미 show 되고 있는 키보드 또한 자동으로 hide되기 때문에 중복하여 메서드가 호출됩니다. 
+- 이전에는 분기 처리를 통하여 해결하였는데, 이번에는 이 과정에서 서버와의 지연으로 인해 분기 처리가 정상적으로 이루어지지 않아 두 세번 저장 메서드가 호출되는 현상이 발생하였습니다.
+- 이로 인한 중복 저장을 막기 위해서 `isFetching` 프로퍼티를 정의해서 현재 데이터를 받아오고 있는 중인지 아닌지 확인할 수 있도록 했습니다.
+- 다만, 이렇게 확인하는 방식이 효율적인지에 대한 의문이 들어, 혹시 데이터가 현재 통신중인지 여부를 체크할 수 있는 더 좋은 방법이 있는지 알고 싶습니다. ☺️
+
+- **기존 코드:**
+```swift
+WeatherImageAPIManager(icon: icon)?.requestImage(id: id) { [weak self] result in
+    switch result {
+    case .success(let image):
+        do {
+            try CoreDataManager.shared.saveDiary(
+                title: title,
+                body: body,
+                createdAt: creationDate,
+                id: id,
+                main: main,
+                icon: icon,
+                image: image
+            )
+        } catch {
+            self?.presentErrorAlert(error)
+        }
+    case .failure(let error):
+        self?.presentErrorAlert(error)
+    }
+}
+```
+
+- **수정 코드:**
+```swift
+if isFetching == false {
+    isFetching = true
+    WeatherImageAPIManager(icon: icon)?.requestImage(id: id) { [weak self] result in
+        switch result {
+        case .success(let image):
+            do {
+                try CoreDataManager.shared.saveDiary(
+                    title: title,
+                    body: body,
+                    createdAt: creationDate,
+                    id: id,
+                    main: main,
+                    icon: icon,
+                    image: image
+                )
+            } catch {
+                self?.presentErrorAlert(error)
+            }
+        case .failure(let error):
+            self?.presentErrorAlert(error)
+        }
+        self?.isFetching = false
+    }
 }
 ```


### PR DESCRIPTION
안녕하세요, @GREENOVER!
벌써 마지막 PR이네요 🥲🥲
궁금한 사항에 대하여 아래와 같이 정리해보았습니다!!
이번 스텝도 잘 부탁드립니다!! 🙇‍♂️🙇

---

### STEP 3
    
**현재 사용자의 위치(Core Location)를 기반으로 현재 날씨정보(Open Weather API) 가져오기**
    
    - Open Weather API 데이터를 fetch해오는 WeatherDataAPIManager 정의
    - CLLocationManager 인스턴스를 생성하여 requestLocation 메서드 호출
    - CLLocationManagerDelegate 프로토콜을 통한 Location 업데이트 시
        - WeatherDataAPIManager를 통해 Weather Data 가져오기
        - diary의 main, icon 프로퍼티 할당
   
## 🚀 TroubleShooting

### STEP 3
#### T1. 일기의 `Title`과 `Body` 구분 로직
- `Title`과 `Body`를 구분하는 이전 로직을 검토해본 결과, `Body`가 없이 `Title`로만 일기를 구성하였을 때도, 일기가 저장되는 것이 옳은 일기장 어플리케이션 구현이라고 판단하였습니다. 이러한 생각을 바탕으로, 로직을 수정하던 중, `Body`의 경우 개행이 2번된 경우, 일기장 리스트 화면에서 `Body`의 내용물이 아닌, 개행으로 인한 빈 내용이 표시되는 문제가 발생하였습니다.
    
- 이를 해결하기 위하여 다음과 같이 코드를 수정해보았습니다. 먼저, `diaryContentView` 내 `textView`의 `text`를 옵셔널 바인딩 후, 개행을 기준으로 `split`을 진행하였습니다. 그리고 `split`된 문자열 배열의 첫번째 구성요소는 `title`에 해당할 것이므로, `title`에 담았고, `title` 값이 없을시, `textView`의 값은 유의미한 글자가 없는 값이므로 `nil` 처리를 하여 일기를 `save`하지 않도록 처리하였습니다. 그리고 만일 `splitText`의 `count`가 1보다 크지 않으면, 선행 조건에서 이어진 경우이기에, `count`가 1인 경우이므로, `title`만 있는 경우이기에 `(String(title), DiaryCoreData.emptyBody)`로 타이틀과 빈 바디를 반환하였습니다. 그리고 전체 `diaryConentViewText`에서 `body`가 시작되는 인덱스부터를 범위로 삼아 `body`를 추출하였습니다.

- 코드
```swift
private func extractTitleAndBody() -> (String, String)? {
    guard let diaryConentViewText = diaryContentView.textView.text else {
        return nil
    }
    
    let splitedText = diaryConentViewText.split(separator: NewLine.lineFeed)
    
    guard let title = splitedText.first else {
        return nil
    }
    
    guard splitedText.count > 1 else {
        return (String(title), DiaryCoreData.emptyBody)
    }
    
    let body = diaryConentViewText[splitedText[1].startIndex...]
    
    return (String(title), String(body))
}
```

## 3️⃣ STEP 3
    
### STEP 3 Questions

#### Q1. 시뮬레이터에서 Location 변경시 정상적으로 적용되지 않는 문제
- 이번 프로젝트를 진행하면서 `CoreLocation`으로 사용자에게 위치 정보를 받아오는 요구사항이 있었습니다.
- 위치가 제대로 들어가는지 확인하기 위해서 `Simulator`에서 `location`을 변경해봤지만, 변경된 위치가 들어가지 않고, 이 전에 설정했던 위치가 계속 들어갔습니다.
- 그런데 정말 이상하게도 아이폰 기본 지도 앱을 한번 실행한 후 다시 테스트를 했을때는 `Location`을 변경해줬을때 바로바로 적용이 되었습니다.

![](https://i.imgur.com/oAmI4Ea.png)

![](https://i.imgur.com/QxV7koj.png)

- ⬆️ 해당 메뉴에서 위치를 변경해도 `Simulator`에서는 바로 적용되지 않는 문제가 발생했습니다.
- 단순히 애플 기본 지도 앱을 실행 후 종료해주는 것 만으로 해결되었습니다.
- 올바른 해결방법이 아니라는 생각이 들어 혹시 원인을 아시는지 궁금합니다 🤔
    
#### Q2. 서버에서 데이터를 받아오고 있는 중인지 체크하는 법
- save 기능이 구현된 메서드가 호출되면 `Weather` 아이콘을 인터넷에서 받아오고 있습니다.
- 하지만 이전 프로젝트 구현 사항으로 일기장의 저장 경우의 수는 일기장 목록으로 되돌아갈 때, 백그라운드에 들어갈 때, 키보드가 내려갈 때로, 총 3가지 경우입니다.
- 그런데 일기장 목록으로 되돌아가면 이미 show 되고 있는 키보드 또한 자동으로 hide되기 때문에 중복하여 메서드가 호출됩니다. 
- 이전에는 분기 처리를 통하여 해결하였는데, 이번에는 이 과정에서 서버와의 지연으로 인해 분기 처리가 정상적으로 이루어지지 않아 두 세번 저장 메서드가 호출되는 현상이 발생하였습니다.
- 이로 인한 중복 저장을 막기 위해서 `isFetching` 프로퍼티를 정의해서 현재 데이터를 받아오고 있는 중인지 아닌지 확인할 수 있도록 했습니다.
- 다만, 이렇게 확인하는 방식이 효율적인지에 대한 의문이 들어, 혹시 데이터가 현재 통신중인지 여부를 체크할 수 있는 더 좋은 방법이 있는지 알고 싶습니다. ☺️

- **기존 코드:**
```swift
WeatherImageAPIManager(icon: icon)?.requestImage(id: id) { [weak self] result in
    switch result {
    case .success(let image):
        do {
            try CoreDataManager.shared.saveDiary(
                title: title,
                body: body,
                createdAt: creationDate,
                id: id,
                main: main,
                icon: icon,
                image: image
            )
        } catch {
            self?.presentErrorAlert(error)
        }
    case .failure(let error):
        self?.presentErrorAlert(error)
    }
}
```

- **수정 코드:**
```swift
if isFetching == false {
    isFetching = true
    WeatherImageAPIManager(icon: icon)?.requestImage(id: id) { [weak self] result in
        switch result {
        case .success(let image):
            do {
                try CoreDataManager.shared.saveDiary(
                    title: title,
                    body: body,
                    createdAt: creationDate,
                    id: id,
                    main: main,
                    icon: icon,
                    image: image
                )
            } catch {
                self?.presentErrorAlert(error)
            }
        case .failure(let error):
            self?.presentErrorAlert(error)
        }
        self?.isFetching = false
    }
}
```