### PR TITLE
일기장 [STEP 2] kaki, 레옹아범

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,6 +5,7 @@ disabled_rules: # Default Rules에서 비활성화할 규칙
     - trailing_whitespace
     - comma
     - colon
+    - empty_enum_arguments
     
 excluded: # SwiftLint 검사에서 제외할 파일 경로
   - Diary/AppDelegate.swift

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,6 +4,7 @@ disabled_rules: # Default Rules에서 비활성화할 규칙
     - trailing_newline
     - trailing_whitespace
     - comma
+    - colon
     
 excluded: # SwiftLint 검사에서 제외할 파일 경로
   - Diary/AppDelegate.swift

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -11,7 +11,8 @@
 		16C0929B29F78B58002ACEB4 /* DiaryInfoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C0929A29F78B58002ACEB4 /* DiaryInfoTableViewCell.swift */; };
 		16C0929D29F78D86002ACEB4 /* ReuseIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C0929C29F78D86002ACEB4 /* ReuseIdentifiable.swift */; };
 		16C0929F29F79642002ACEB4 /* ArrayExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C0929E29F79642002ACEB4 /* ArrayExtension.swift */; };
-		2600B96D29F792C60032E5BD /* Diary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2600B96C29F792C60032E5BD /* Diary.swift */; };
+		16C50AC22A009C4800D1B1C6 /* PersistenceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C50AC12A009C4800D1B1C6 /* PersistenceManager.swift */; };
+		2600B96D29F792C60032E5BD /* JsonDiary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2600B96C29F792C60032E5BD /* JsonDiary.swift */; };
 		2600B96F29F79AFC0032E5BD /* DateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2600B96E29F79AFC0032E5BD /* DateExtension.swift */; };
 		2644766C29FFB8E7007C0BF3 /* DiaryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2644766B29FFB8E7007C0BF3 /* DiaryState.swift */; };
 		268A806F29F6569C0071A59E /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 268A806E29F6569C0071A59E /* .swiftlint.yml */; };
@@ -28,7 +29,8 @@
 		16C0929A29F78B58002ACEB4 /* DiaryInfoTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryInfoTableViewCell.swift; sourceTree = "<group>"; };
 		16C0929C29F78D86002ACEB4 /* ReuseIdentifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReuseIdentifiable.swift; sourceTree = "<group>"; };
 		16C0929E29F79642002ACEB4 /* ArrayExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayExtension.swift; sourceTree = "<group>"; };
-		2600B96C29F792C60032E5BD /* Diary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Diary.swift; sourceTree = "<group>"; };
+		16C50AC12A009C4800D1B1C6 /* PersistenceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceManager.swift; sourceTree = "<group>"; };
+		2600B96C29F792C60032E5BD /* JsonDiary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonDiary.swift; sourceTree = "<group>"; };
 		2600B96E29F79AFC0032E5BD /* DateExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtension.swift; sourceTree = "<group>"; };
 		2644766B29FFB8E7007C0BF3 /* DiaryState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryState.swift; sourceTree = "<group>"; };
 		268A806E29F6569C0071A59E /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
@@ -56,8 +58,9 @@
 		2600B97029F7A2980032E5BD /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				2600B96C29F792C60032E5BD /* Diary.swift */,
+				2600B96C29F792C60032E5BD /* JsonDiary.swift */,
 				2644766B29FFB8E7007C0BF3 /* DiaryState.swift */,
+				16C50AC12A009C4800D1B1C6 /* PersistenceManager.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -220,6 +223,7 @@
 				16C0929D29F78D86002ACEB4 /* ReuseIdentifiable.swift in Sources */,
 				C739AE29284DF28600741E8F /* DiaryViewController.swift in Sources */,
 				2644766C29FFB8E7007C0BF3 /* DiaryState.swift in Sources */,
+				16C50AC22A009C4800D1B1C6 /* PersistenceManager.swift in Sources */,
 				C739AE25284DF28600741E8F /* AppDelegate.swift in Sources */,
 				16C0929F29F79642002ACEB4 /* ArrayExtension.swift in Sources */,
 				2600B96F29F79AFC0032E5BD /* DateExtension.swift in Sources */,
@@ -227,7 +231,7 @@
 				C739AE2F284DF28600741E8F /* Diary.xcdatamodeld in Sources */,
 				166C22AB29F7ECAF00E527AC /* DiaryDetailViewController.swift in Sources */,
 				16C0929B29F78B58002ACEB4 /* DiaryInfoTableViewCell.swift in Sources */,
-				2600B96D29F792C60032E5BD /* Diary.swift in Sources */,
+				2600B96D29F792C60032E5BD /* JsonDiary.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		165F05C92A08E71F0018B237 /* CoreDataError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165F05C82A08E71F0018B237 /* CoreDataError.swift */; };
 		166C22AB29F7ECAF00E527AC /* DiaryDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166C22AA29F7ECAF00E527AC /* DiaryDetailViewController.swift */; };
 		16C0929B29F78B58002ACEB4 /* DiaryInfoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C0929A29F78B58002ACEB4 /* DiaryInfoTableViewCell.swift */; };
 		16C0929D29F78D86002ACEB4 /* ReuseIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C0929C29F78D86002ACEB4 /* ReuseIdentifiable.swift */; };
@@ -26,6 +27,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		165F05C82A08E71F0018B237 /* CoreDataError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataError.swift; sourceTree = "<group>"; };
 		166C22AA29F7ECAF00E527AC /* DiaryDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryDetailViewController.swift; sourceTree = "<group>"; };
 		16C0929A29F78B58002ACEB4 /* DiaryInfoTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryInfoTableViewCell.swift; sourceTree = "<group>"; };
 		16C0929C29F78D86002ACEB4 /* ReuseIdentifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReuseIdentifiable.swift; sourceTree = "<group>"; };
@@ -63,6 +65,7 @@
 				2600B96C29F792C60032E5BD /* JsonDiary.swift */,
 				2644766B29FFB8E7007C0BF3 /* DiaryState.swift */,
 				16C50AC12A009C4800D1B1C6 /* PersistenceManager.swift */,
+				165F05C82A08E71F0018B237 /* CoreDataError.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -236,6 +239,7 @@
 				166C22AB29F7ECAF00E527AC /* DiaryDetailViewController.swift in Sources */,
 				16C0929B29F78B58002ACEB4 /* DiaryInfoTableViewCell.swift in Sources */,
 				2600B96D29F792C60032E5BD /* JsonDiary.swift in Sources */,
+				165F05C92A08E71F0018B237 /* CoreDataError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		16C0929D29F78D86002ACEB4 /* ReuseIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C0929C29F78D86002ACEB4 /* ReuseIdentifiable.swift */; };
 		16C0929F29F79642002ACEB4 /* ArrayExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C0929E29F79642002ACEB4 /* ArrayExtension.swift */; };
 		16C50AC22A009C4800D1B1C6 /* PersistenceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C50AC12A009C4800D1B1C6 /* PersistenceManager.swift */; };
+		16C50AC42A00D5C200D1B1C6 /* UIViewControllerExtention.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C50AC32A00D5C200D1B1C6 /* UIViewControllerExtention.swift */; };
 		2600B96D29F792C60032E5BD /* JsonDiary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2600B96C29F792C60032E5BD /* JsonDiary.swift */; };
 		2600B96F29F79AFC0032E5BD /* DateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2600B96E29F79AFC0032E5BD /* DateExtension.swift */; };
 		2644766C29FFB8E7007C0BF3 /* DiaryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2644766B29FFB8E7007C0BF3 /* DiaryState.swift */; };
@@ -30,6 +31,7 @@
 		16C0929C29F78D86002ACEB4 /* ReuseIdentifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReuseIdentifiable.swift; sourceTree = "<group>"; };
 		16C0929E29F79642002ACEB4 /* ArrayExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayExtension.swift; sourceTree = "<group>"; };
 		16C50AC12A009C4800D1B1C6 /* PersistenceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceManager.swift; sourceTree = "<group>"; };
+		16C50AC32A00D5C200D1B1C6 /* UIViewControllerExtention.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewControllerExtention.swift; sourceTree = "<group>"; };
 		2600B96C29F792C60032E5BD /* JsonDiary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonDiary.swift; sourceTree = "<group>"; };
 		2600B96E29F79AFC0032E5BD /* DateExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtension.swift; sourceTree = "<group>"; };
 		2644766B29FFB8E7007C0BF3 /* DiaryState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryState.swift; sourceTree = "<group>"; };
@@ -88,6 +90,7 @@
 				16C0929C29F78D86002ACEB4 /* ReuseIdentifiable.swift */,
 				16C0929E29F79642002ACEB4 /* ArrayExtension.swift */,
 				2600B96E29F79AFC0032E5BD /* DateExtension.swift */,
+				16C50AC32A00D5C200D1B1C6 /* UIViewControllerExtention.swift */,
 			);
 			path = Etc;
 			sourceTree = "<group>";
@@ -225,6 +228,7 @@
 				2644766C29FFB8E7007C0BF3 /* DiaryState.swift in Sources */,
 				16C50AC22A009C4800D1B1C6 /* PersistenceManager.swift in Sources */,
 				C739AE25284DF28600741E8F /* AppDelegate.swift in Sources */,
+				16C50AC42A00D5C200D1B1C6 /* UIViewControllerExtention.swift in Sources */,
 				16C0929F29F79642002ACEB4 /* ArrayExtension.swift in Sources */,
 				2600B96F29F79AFC0032E5BD /* DateExtension.swift in Sources */,
 				C739AE27284DF28600741E8F /* SceneDelegate.swift in Sources */,

--- a/Diary/Controller/DiaryDetailViewController.swift
+++ b/Diary/Controller/DiaryDetailViewController.swift
@@ -155,7 +155,11 @@ extension DiaryDetailViewController {
         let alertController = UIAlertController(title: nil,
                                                 message: nil,
                                                 preferredStyle: .actionSheet)
-        let shareAction = UIAlertAction(title: "Share...", style: .default)
+        let shareAction = UIAlertAction(title: "Share...", style: .default) { [weak self] _ in
+            guard let text = self?.diaryItem?.content else { return }
+            
+            self?.showActivityView(text)
+        }
         let deleteAction = UIAlertAction(title: "Delete", style: .destructive) { [weak self] _ in
             self?.showDeleteAlert()
         }

--- a/Diary/Controller/DiaryDetailViewController.swift
+++ b/Diary/Controller/DiaryDetailViewController.swift
@@ -74,6 +74,7 @@ final class DiaryDetailViewController: UIViewController {
                 showFailAlert(error: error)
             }
         }
+        state = .edit
     }
     
     private func configureInitailView() {
@@ -91,7 +92,6 @@ final class DiaryDetailViewController: UIViewController {
         self.view.endEditing(true)
         
         endEditingDiary()
-        state = .edit
     }
 }
 

--- a/Diary/Controller/DiaryDetailViewController.swift
+++ b/Diary/Controller/DiaryDetailViewController.swift
@@ -35,12 +35,6 @@ final class DiaryDetailViewController: UIViewController {
         }
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        
-        endEditingDiary()
-    }
-    
     init(diaryItem: Diary? = nil, state: DiaryState) {
         self.diaryItem = diaryItem
         self.state = state

--- a/Diary/Controller/DiaryDetailViewController.swift
+++ b/Diary/Controller/DiaryDetailViewController.swift
@@ -169,13 +169,13 @@ extension DiaryDetailViewController {
         let alertController = UIAlertController(title: nil,
                                                 message: nil,
                                                 preferredStyle: .actionSheet)
-        let shareAction = UIAlertAction(title: "Share...", style: .default) { [weak self] _ in
-            guard let text = self?.diaryItem?.content else { return }
+        let shareAction = UIAlertAction(title: "Share...", style: .default) { _ in
+            guard let text = self.diaryItem?.content else { return }
             
-            self?.showActivityView(text)
+            self.showActivityView(text)
         }
-        let deleteAction = UIAlertAction(title: "Delete", style: .destructive) { [weak self] _ in
-            self?.showDeleteAlert()
+        let deleteAction = UIAlertAction(title: "Delete", style: .destructive) { _ in
+            self.showDeleteAlert()
         }
         let cancelAction = UIAlertAction(title: "Cancle", style: .cancel)
         

--- a/Diary/Controller/DiaryDetailViewController.swift
+++ b/Diary/Controller/DiaryDetailViewController.swift
@@ -17,7 +17,7 @@ final class DiaryDetailViewController: UIViewController {
     }()
     private var diaryItem: Diary?
     private var state: DiaryState
-    private let manager = PersistenceManager.shared
+    private let manager = PersistenceManager()
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Diary/Controller/DiaryDetailViewController.swift
+++ b/Diary/Controller/DiaryDetailViewController.swift
@@ -35,12 +35,6 @@ final class DiaryDetailViewController: UIViewController {
         }
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        
-        endEditingDiary()
-    }
-    
     init(diaryItem: Diary? = nil, state: DiaryState) {
         self.diaryItem = diaryItem
         self.state = state
@@ -57,6 +51,8 @@ final class DiaryDetailViewController: UIViewController {
     }
     
     private func configureInitailView() {
+        self.navigationController?.delegate = self
+        
         guard let diaryItem = diaryItem else {
             self.navigationItem.title = Date.convertToDate(by: Date().timeIntervalSince1970)
             
@@ -114,6 +110,15 @@ final class DiaryDetailViewController: UIViewController {
     }
 }
 
+extension DiaryDetailViewController: UINavigationControllerDelegate {
+    func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
+        guard let diaryViewController = viewController as? DiaryViewController else { return }
+        
+        endEditingDiary()
+        diaryViewController.fetchDiary()
+    }
+}
+
 // MARK: UI
 extension DiaryDetailViewController {
     private func configureUI() {
@@ -156,12 +161,6 @@ extension DiaryDetailViewController {
         let deleteAction = UIAlertAction(title: "삭제", style: .destructive) { [weak self] _ in
             guard let diaryItem = self?.diaryItem else { return }
             
-//            do {
-//                try self?.manager.deleteContent(at: diaryItem)
-//                self?.navigationController?.popViewController(animated: true)
-//            } catch {
-//                self?.showFailAlert(error: error)
-//            }
             self?.manager.deleteContent(at: diaryItem, completion: { [weak self] result in
                 switch result {
                 case .success():

--- a/Diary/Controller/DiaryDetailViewController.swift
+++ b/Diary/Controller/DiaryDetailViewController.swift
@@ -15,7 +15,7 @@ final class DiaryDetailViewController: UIViewController {
         
         return textView
     }()
-    private var diaryItem: Diary
+    private var diaryItem: JsonDiary
     private let state: DiaryState
     
     override func viewDidLoad() {
@@ -24,7 +24,7 @@ final class DiaryDetailViewController: UIViewController {
         configureUI()
     }
     
-    init(diaryItem: Diary, state: DiaryState) {
+    init(diaryItem: JsonDiary, state: DiaryState) {
         self.diaryItem = diaryItem
         self.state = state
         super.init(nibName: nil, bundle: nil)

--- a/Diary/Controller/DiaryDetailViewController.swift
+++ b/Diary/Controller/DiaryDetailViewController.swift
@@ -85,20 +85,38 @@ final class DiaryDetailViewController: UIViewController {
         
         switch state {
         case .create:
-            do {
-                let date = Date().timeIntervalSince1970
-                diaryItem = try manager.createContent(content, date)
-                state = .edit
-            } catch {
-                showFailAlert(error: error)
+//            do {
+//                let date = Date().timeIntervalSince1970
+//                diaryItem = try manager.createContent(content, date)
+//                state = .edit
+//            } catch {
+//                showFailAlert(error: error)
+//            }
+            let date = Date().timeIntervalSince1970
+            manager.createContent(content, date) { [weak self] result in
+                switch result {
+                case .success(let diary):
+                    self?.diaryItem = diary
+                    self?.state = .edit
+                case .failure(let error):
+                    self?.showFailAlert(error: error)
+                }
             }
         case .edit:
             guard let diary = diaryItem else { return }
             
-            do {
-                try manager.updateContent(at: diary, content)
-            } catch {
-                showFailAlert(error: error)
+//            do {
+//                try manager.updateContent(at: diary, content)
+//            } catch {
+//                showFailAlert(error: error)
+//            }
+            manager.updateContent(at: diary, content) { [weak self] result in
+                switch result {
+                case .success():
+                    return
+                case .failure(let error):
+                    self?.showFailAlert(error: error)
+                }
             }
         }
     }
@@ -150,12 +168,20 @@ extension DiaryDetailViewController {
         let deleteAction = UIAlertAction(title: "삭제", style: .destructive) { [weak self] _ in
             guard let diaryItem = self?.diaryItem else { return }
             
-            do {
-                try self?.manager.deleteContent(at: diaryItem)
-                self?.navigationController?.popViewController(animated: true)
-            } catch {
-                self?.showFailAlert(error: error)
-            }
+//            do {
+//                try self?.manager.deleteContent(at: diaryItem)
+//                self?.navigationController?.popViewController(animated: true)
+//            } catch {
+//                self?.showFailAlert(error: error)
+//            }
+            self?.manager.deleteContent(at: diaryItem, completion: { [weak self] result in
+                switch result {
+                case .success():
+                    self?.navigationController?.popViewController(animated: true)
+                case .failure(let error):
+                    self?.showFailAlert(error: error)
+                }
+            })
         }
         
         alert.addAction(cancelAction)

--- a/Diary/Controller/DiaryDetailViewController.swift
+++ b/Diary/Controller/DiaryDetailViewController.swift
@@ -79,7 +79,7 @@ final class DiaryDetailViewController: UIViewController {
     }
     
     @objc private func endEditingDiary() {
-        if diaryTextView.text.isEmpty { return }
+        guard !diaryTextView.text.isEmpty else { return }
         
         let content = diaryTextView.text
         

--- a/Diary/Controller/DiaryDetailViewController.swift
+++ b/Diary/Controller/DiaryDetailViewController.swift
@@ -26,7 +26,7 @@ final class DiaryDetailViewController: UIViewController {
         configureInitailView()
         setupNotification()
     }
-
+    
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
@@ -100,8 +100,6 @@ final class DiaryDetailViewController: UIViewController {
             } catch {
                 showFailAlert(error: error)
             }
-        case .delete:
-            return
         }
     }
     
@@ -154,7 +152,6 @@ extension DiaryDetailViewController {
             
             do {
                 try self?.manager.deleteContent(at: diaryItem)
-                self?.state = .delete
                 self?.navigationController?.popViewController(animated: true)
             } catch {
                 self?.showFailAlert(error: error)

--- a/Diary/Controller/DiaryDetailViewController.swift
+++ b/Diary/Controller/DiaryDetailViewController.swift
@@ -23,6 +23,7 @@ final class DiaryDetailViewController: UIViewController {
         super.viewDidLoad()
         
         configureUI()
+        configureInitailView()
         
         NotificationCenter.default.addObserver(self, selector: #selector(endEditingDiary), name: UIScene.didEnterBackgroundNotification, object: nil)
     }
@@ -101,7 +102,17 @@ extension DiaryDetailViewController {
         
         diaryTextView.addDoneButton(title: "Done", target: self, selector: #selector(doneButtonTapped))
         configureTextView()
-        configureInitailView()
+        configureNavigationController()
+    }
+    
+    private func configureNavigationController() {
+        let image = UIImage(systemName: "ellipsis.circle")
+        let rightItem = UIBarButtonItem(image: image,
+                                        style: .plain,
+                                        target: self,
+                                        action: #selector(showActionSheet))
+        
+        navigationItem.rightBarButtonItem = rightItem
     }
     
     private func configureTextView() {
@@ -113,6 +124,20 @@ extension DiaryDetailViewController {
             diaryTextView.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor),
             diaryTextView.bottomAnchor.constraint(equalTo: self.view.keyboardLayoutGuide.topAnchor)
         ])
+    }
+    
+    @objc private func showActionSheet() {
+        let alertController = UIAlertController(title: nil,
+                                                message: nil,
+                                                preferredStyle: .actionSheet)
+        let shareAction = UIAlertAction(title: "Share...", style: .default)
+        let deleteAction = UIAlertAction(title: "Delete", style: .destructive)
+        let cancelAction = UIAlertAction(title: "Cancle", style: .cancel)
+        
+        alertController.addAction(shareAction)
+        alertController.addAction(deleteAction)
+        alertController.addAction(cancelAction)
+        present(alertController, animated: true)
     }
 }
 

--- a/Diary/Controller/DiaryDetailViewController.swift
+++ b/Diary/Controller/DiaryDetailViewController.swift
@@ -35,6 +35,12 @@ final class DiaryDetailViewController: UIViewController {
         }
     }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        endEditingDiary()
+    }
+    
     init(diaryItem: Diary? = nil, state: DiaryState) {
         self.diaryItem = diaryItem
         self.state = state
@@ -43,6 +49,11 @@ final class DiaryDetailViewController: UIViewController {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self, name: UIScene.didEnterBackgroundNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
     }
     
     private func configureInitailView() {
@@ -119,6 +130,7 @@ extension DiaryDetailViewController {
     }
     
     private func configureTextView() {
+        diaryTextView.contentInsetAdjustmentBehavior = .never
         self.view.addSubview(diaryTextView)
         diaryTextView.addDoneButton(title: "Done",
                                     target: self,

--- a/Diary/Controller/DiaryDetailViewController.swift
+++ b/Diary/Controller/DiaryDetailViewController.swift
@@ -85,13 +85,6 @@ final class DiaryDetailViewController: UIViewController {
         
         switch state {
         case .create:
-//            do {
-//                let date = Date().timeIntervalSince1970
-//                diaryItem = try manager.createContent(content, date)
-//                state = .edit
-//            } catch {
-//                showFailAlert(error: error)
-//            }
             let date = Date().timeIntervalSince1970
             manager.createContent(content, date) { [weak self] result in
                 switch result {
@@ -105,11 +98,6 @@ final class DiaryDetailViewController: UIViewController {
         case .edit:
             guard let diary = diaryItem else { return }
             
-//            do {
-//                try manager.updateContent(at: diary, content)
-//            } catch {
-//                showFailAlert(error: error)
-//            }
             manager.updateContent(at: diary, content) { [weak self] result in
                 switch result {
                 case .success():

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 final class DiaryViewController: UIViewController {
     private let tableView: UITableView = UITableView()
     private var diaryItems: [Diary] = []
-    private let manager = PersistenceManager.shared
+    private let manager = PersistenceManager()
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -87,7 +87,9 @@ extension DiaryViewController: UITableViewDelegate {
         deleteContextualAction.image = UIImage(systemName: "trash.fill")?.withTintColor(.white)
         deleteContextualAction.backgroundColor = .systemRed
         
-        let shareContextualAction = UIContextualAction(style: .normal, title: nil) { [weak self] _, _, completionHandler in
+        let shareContextualAction = UIContextualAction(
+            style: .normal,
+            title: nil) { [weak self] _, _, completionHandler in
             guard let text = self?.diaryItems[safe: indexPath.row]?.content else { return }
             
             self?.showActivityView(text)

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -8,7 +8,8 @@ import UIKit
 
 final class DiaryViewController: UIViewController {
     private let tableView: UITableView = UITableView()
-    private var diaryItems: [JsonDiary] = []
+    private var diaryItems: [Diary] = []
+    private let manager = PersistenceManager.shared
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -17,30 +18,27 @@ final class DiaryViewController: UIViewController {
         
         tableView.dataSource = self
         tableView.delegate = self
-        
-        parseSampleData()
     }
     
-    private func parseSampleData() {
-        guard let dataAsset = NSDataAsset(name: "sample") else { return }
-        
-        let decoder = JSONDecoder()
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         
         do {
-            diaryItems = try decoder.decode([JsonDiary].self, from: dataAsset.data)
+            diaryItems = try manager.fetchContent()
+            tableView.reloadData()
         } catch {
             showFailAlert(error: error)
         }
     }
     
-    private func pushDiaryDetailViewController(with diary: JsonDiary, _ state: DiaryState) {
+    private func pushDiaryDetailViewController(with diary: Diary? = nil, _ state: DiaryState) {
         let detailVC = DiaryDetailViewController(diaryItem: diary, state: state)
         
         self.navigationController?.pushViewController(detailVC, animated: true)
     }
     
     @objc private func plusButtonTapped() {
-        pushDiaryDetailViewController(with: JsonDiary(), .create)
+        pushDiaryDetailViewController(.create)
     }
 }
 

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -8,7 +8,7 @@ import UIKit
 
 final class DiaryViewController: UIViewController {
     private let tableView: UITableView = UITableView()
-    private var diaryItems: [Diary] = []
+    private var diaryItems: [JsonDiary] = []
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -27,20 +27,20 @@ final class DiaryViewController: UIViewController {
         let decoder = JSONDecoder()
         
         do {
-            diaryItems = try decoder.decode([Diary].self, from: dataAsset.data)
+            diaryItems = try decoder.decode([JsonDiary].self, from: dataAsset.data)
         } catch {
             showFailAlert(error: error)
         }
     }
     
-    private func pushDiaryDetailViewController(with diary: Diary, _ state: DiaryState) {
+    private func pushDiaryDetailViewController(with diary: JsonDiary, _ state: DiaryState) {
         let detailVC = DiaryDetailViewController(diaryItem: diary, state: state)
         
         self.navigationController?.pushViewController(detailVC, animated: true)
     }
     
     @objc private func plusButtonTapped() {
-        pushDiaryDetailViewController(with: Diary(), .create)
+        pushDiaryDetailViewController(with: JsonDiary(), .create)
     }
 }
 

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -23,11 +23,20 @@ final class DiaryViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        do {
-            diaryItems = try manager.fetchContent()
-            tableView.reloadData()
-        } catch {
-            showFailAlert(error: error)
+//        do {
+//            diaryItems = try manager.fetchContent()
+//            tableView.reloadData()
+//        } catch {
+//            showFailAlert(error: error)
+//        }
+        manager.fetchContent { [weak self] result in
+            switch result {
+            case .success(let diary):
+                self?.diaryItems = diary
+                self?.tableView.reloadData()
+            case .failure(let error):
+                self?.showFailAlert(error: error)
+            }
         }
     }
     
@@ -38,14 +47,25 @@ final class DiaryViewController: UIViewController {
     }
     
     private func deleteTableViewItem(item: Diary, indexPath: IndexPath) {
-        do {
-            try manager.deleteContent(at: item)
-            tableView.performBatchUpdates {
-                diaryItems.remove(at: indexPath.row)
-                tableView.deleteRows(at: [indexPath], with: .automatic)
+//        do {
+//            try manager.deleteContent(at: item)
+//            tableView.performBatchUpdates {
+//                diaryItems.remove(at: indexPath.row)
+//                tableView.deleteRows(at: [indexPath], with: .automatic)
+//            }
+//        } catch {
+//            showFailAlert(error: error)
+//        }
+        manager.deleteContent(at: item) { [weak self] result in
+            switch result {
+            case .success():
+                self?.tableView.performBatchUpdates({
+                    self?.diaryItems.remove(at: indexPath.row)
+                    self?.tableView.deleteRows(at: [indexPath], with: .automatic)
+                })
+            case .failure(let error):
+                self?.showFailAlert(error: error)
             }
-        } catch {
-            showFailAlert(error: error)
         }
     }
     

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -68,7 +68,20 @@ extension DiaryViewController: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-        let deleteContextualAction = UIContextualAction(style: .destructive, title: nil) { _, _, _ in
+        let deleteContextualAction = UIContextualAction(
+            style: .destructive,
+            title: nil) { [weak self] _, _, completionHandler in
+            guard let diary = self?.diaryItems[safe: indexPath.row] else { return }
+            
+            do {
+                try self?.manager.deleteContent(at: diary)
+                self?.diaryItems.remove(at: indexPath.row)
+                self?.tableView.reloadData()
+                completionHandler(true)
+            } catch {
+                self?.showFailAlert(error: error)
+                completionHandler(false)
+            }
         }
         
         deleteContextualAction.image = UIImage(systemName: "trash.fill")?.withTintColor(.white)

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -66,6 +66,24 @@ extension DiaryViewController: UITableViewDelegate {
         
         pushDiaryDetailViewController(with: diary, .edit)
     }
+    
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        let deleteContextualAction = UIContextualAction(style: .destructive, title: nil) { _, _, _ in
+        }
+        
+        deleteContextualAction.image = UIImage(systemName: "trash.fill")?.withTintColor(.white)
+        deleteContextualAction.backgroundColor = .systemRed
+        
+        let shareContextualAction = UIContextualAction(style: .normal, title: nil) { _, _, _ in
+        }
+        
+        shareContextualAction.image = UIImage(systemName: "square.and.arrow.up")
+        shareContextualAction.backgroundColor = .systemBlue
+        
+        let configuration = UISwipeActionsConfiguration(actions: [deleteContextualAction, shareContextualAction])
+        
+        return configuration
+    }
 }
 
 // MARK: UI

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -15,14 +15,13 @@ final class DiaryViewController: UIViewController {
         super.viewDidLoad()
         
         configureUI()
+        fetchDiary()
         
         tableView.dataSource = self
         tableView.delegate = self
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
+    func fetchDiary() {
         manager.fetchContent { [weak self] result in
             switch result {
             case .success(let diary):

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -76,15 +76,6 @@ extension DiaryViewController {
         configureNavigationController()
     }
     
-    private func showFailAlert(error: Error) {
-        let alert = UIAlertController(title: "Error",
-                                      message: "데이터 로딩 실패 \n \(error.localizedDescription)",
-                                      preferredStyle: .alert)
-        let okAction = UIAlertAction(title: "확인", style: .default)
-        alert.addAction(okAction)
-        present(alert, animated: true)
-    }
-    
     private func configureTableView() {
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.register(DiaryInfoTableViewCell.self, forCellReuseIdentifier: DiaryInfoTableViewCell.identifier)

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -23,12 +23,6 @@ final class DiaryViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-//        do {
-//            diaryItems = try manager.fetchContent()
-//            tableView.reloadData()
-//        } catch {
-//            showFailAlert(error: error)
-//        }
         manager.fetchContent { [weak self] result in
             switch result {
             case .success(let diary):
@@ -47,15 +41,6 @@ final class DiaryViewController: UIViewController {
     }
     
     private func deleteTableViewItem(item: Diary, indexPath: IndexPath) {
-//        do {
-//            try manager.deleteContent(at: item)
-//            tableView.performBatchUpdates {
-//                diaryItems.remove(at: indexPath.row)
-//                tableView.deleteRows(at: [indexPath], with: .automatic)
-//            }
-//        } catch {
-//            showFailAlert(error: error)
-//        }
         manager.deleteContent(at: item) { [weak self] result in
             switch result {
             case .success():

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -40,9 +40,9 @@ final class DiaryViewController: UIViewController {
     private func deleteTableViewItem(item: Diary, indexPath: IndexPath) {
         do {
             try manager.deleteContent(at: item)
-            tableView.performBatchUpdates { [weak self] in
-                self?.diaryItems.remove(at: indexPath.row)
-                self?.tableView.deleteRows(at: [indexPath], with: .automatic)
+            tableView.performBatchUpdates {
+                diaryItems.remove(at: indexPath.row)
+                tableView.deleteRows(at: [indexPath], with: .automatic)
             }
         } catch {
             showFailAlert(error: error)

--- a/Diary/Controller/DiaryViewController.swift
+++ b/Diary/Controller/DiaryViewController.swift
@@ -87,7 +87,11 @@ extension DiaryViewController: UITableViewDelegate {
         deleteContextualAction.image = UIImage(systemName: "trash.fill")?.withTintColor(.white)
         deleteContextualAction.backgroundColor = .systemRed
         
-        let shareContextualAction = UIContextualAction(style: .normal, title: nil) { _, _, _ in
+        let shareContextualAction = UIContextualAction(style: .normal, title: nil) { [weak self] _, _, completionHandler in
+            guard let text = self?.diaryItems[safe: indexPath.row]?.content else { return }
+            
+            self?.showActivityView(text)
+            completionHandler(true)
         }
         
         shareContextualAction.image = UIImage(systemName: "square.and.arrow.up")

--- a/Diary/Diary.xcdatamodeld/Diary.xcdatamodel/contents
+++ b/Diary/Diary.xcdatamodeld/Diary.xcdatamodel/contents
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="1" systemVersion="11A491" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="false" userDefinedModelVersionIdentifier="">
-    <elements/>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22E261" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Diary" representedClassName="Diary" syncable="YES" codeGenerationType="class">
+        <attribute name="content" optional="YES" attributeType="String"/>
+        <attribute name="date" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+    </entity>
 </model>

--- a/Diary/Etc/ArrayExtension.swift
+++ b/Diary/Etc/ArrayExtension.swift
@@ -9,4 +9,8 @@ extension Array {
     subscript (safe index: Int) -> Element? {
         return indices ~= index ? self[index] : nil
     }
+    
+    subscript (safe index: PartialRangeFrom<Int>) -> Array<Element>.SubSequence? {
+        return indices ~= index.lowerBound ? self[index] : nil
+    }
 }

--- a/Diary/Etc/UIViewControllerExtention.swift
+++ b/Diary/Etc/UIViewControllerExtention.swift
@@ -1,0 +1,19 @@
+//
+//  UIViewControllerExtention.swift
+//  Diary
+//
+//  Created by kaki, 레옹아범 on 2023/05/02.
+//
+
+import UIKit
+
+extension UIViewController {
+    func showFailAlert(error: Error) {
+        let alert = UIAlertController(title: "Error",
+                                      message: "데이터 로딩 실패 \n \(error.localizedDescription)",
+                                      preferredStyle: .alert)
+        let okAction = UIAlertAction(title: "확인", style: .default)
+        alert.addAction(okAction)
+        present(alert, animated: true)
+    }
+}

--- a/Diary/Etc/UIViewControllerExtention.swift
+++ b/Diary/Etc/UIViewControllerExtention.swift
@@ -17,7 +17,9 @@ extension UIViewController {
         present(alert, animated: true)
     }
     
-    func showActivityView(_ text: String) {
+    func showActivityView(_ text: String?) {
+        guard let text = text else { return }
+        
         let activityView = UIActivityViewController(activityItems: [text], applicationActivities: nil)
         
         present(activityView, animated: true)

--- a/Diary/Etc/UIViewControllerExtention.swift
+++ b/Diary/Etc/UIViewControllerExtention.swift
@@ -10,7 +10,7 @@ import UIKit
 extension UIViewController {
     func showFailAlert(error: Error) {
         let alert = UIAlertController(title: "Error",
-                                      message: "데이터 로딩 실패 \n \(error.localizedDescription)",
+                                      message: "요청한 작업 실패 \n \(error.localizedDescription)",
                                       preferredStyle: .alert)
         let okAction = UIAlertAction(title: "확인", style: .default)
         alert.addAction(okAction)

--- a/Diary/Etc/UIViewControllerExtention.swift
+++ b/Diary/Etc/UIViewControllerExtention.swift
@@ -16,4 +16,10 @@ extension UIViewController {
         alert.addAction(okAction)
         present(alert, animated: true)
     }
+    
+    func showActivityView(_ text: String) {
+        let activityView = UIActivityViewController(activityItems: [UIImage(systemName: "star.fill")!, text, "abc"], applicationActivities: nil)
+        
+        present(activityView, animated: true)
+    }
 }

--- a/Diary/Etc/UIViewControllerExtention.swift
+++ b/Diary/Etc/UIViewControllerExtention.swift
@@ -18,7 +18,7 @@ extension UIViewController {
     }
     
     func showActivityView(_ text: String) {
-        let activityView = UIActivityViewController(activityItems: [UIImage(systemName: "star.fill")!, text, "abc"], applicationActivities: nil)
+        let activityView = UIActivityViewController(activityItems: [text], applicationActivities: nil)
         
         present(activityView, animated: true)
     }

--- a/Diary/Model/CoreDataError.swift
+++ b/Diary/Model/CoreDataError.swift
@@ -1,0 +1,31 @@
+//
+//  CoreDataError.swift
+//  Diary
+//
+//  Created by kaki, 레옹아범 on 2023/05/08.
+//
+
+import Foundation
+
+enum CoreDataError: LocalizedError {
+    case persistentLoadError
+    case createError
+    case fetchError
+    case updateError
+    case deleteError
+    
+    var errorDescription: String? {
+        switch self {
+        case .persistentLoadError:
+            return "영구저장소 로딩 실패"
+        case .createError:
+            return "생성 실패"
+        case .fetchError:
+            return "불러오기 실패"
+        case .updateError:
+            return "업데이트 실패"
+        case .deleteError:
+            return "삭제 실패"
+        }
+    }
+}

--- a/Diary/Model/DiaryState.swift
+++ b/Diary/Model/DiaryState.swift
@@ -8,4 +8,5 @@
 enum DiaryState {
     case create
     case edit
+    case delete
 }

--- a/Diary/Model/DiaryState.swift
+++ b/Diary/Model/DiaryState.swift
@@ -8,5 +8,4 @@
 enum DiaryState {
     case create
     case edit
-    case delete
 }

--- a/Diary/Model/JsonDiary.swift
+++ b/Diary/Model/JsonDiary.swift
@@ -7,10 +7,14 @@
 
 import Foundation
 
-struct Diary: Decodable {
+struct JsonDiary: Decodable {
     var title: String
     var body: String
     var date: Double
+    
+    var content: String {
+        return title + "\n\n" + body
+    }
     
     private enum CodingKeys: String, CodingKey {
         case title, body

--- a/Diary/Model/PersistenceManager.swift
+++ b/Diary/Model/PersistenceManager.swift
@@ -39,13 +39,9 @@ final class PersistenceManager {
         
         guard let diary = managedObject as? Diary else { return nil }
         
-        do {
-            try context.save()
-            
-            return diary
-        } catch {
-            throw error
-        }
+        try context.save()
+        
+        return diary
     }
     
     func fetchContent() throws -> [Diary] {
@@ -54,34 +50,24 @@ final class PersistenceManager {
         
         fetchRequest.sortDescriptors = [sort]
         
-        do {
-            let diaryData = try context.fetch(fetchRequest)
-            
-            return diaryData
-        } catch {
-            throw error
-        }
+        let diaryData = try context.fetch(fetchRequest)
+        
+        return diaryData
     }
     
     func updateContent(at diary: Diary, _ content: String?) throws {
-        do {
-            let item = try context.existingObject(with: diary.objectID)
-            
-            item.setValue(content, forKey: "content")
-            try context.save()
-        } catch {
-            throw error
-        }
+        let item = try context.existingObject(with: diary.objectID)
+        
+        item.setValue(content, forKey: "content")
+        
+        try context.save()
     }
     
     func deleteContent(at diary: Diary) throws {
-        do {
-            let item = try context.existingObject(with: diary.objectID)
-            
-            context.delete(item)
-            try context.save()
-        } catch {
-            throw error
-        }
+        let item = try context.existingObject(with: diary.objectID)
+        
+        context.delete(item)
+        
+        try context.save()
     }
 }

--- a/Diary/Model/PersistenceManager.swift
+++ b/Diary/Model/PersistenceManager.swift
@@ -28,11 +28,11 @@ final class PersistenceManager {
     private init() { }
     
     // MARK: - Create
-    func createContent(with diary: Diary) throws {
+    func createContent(_ content: String?, _ date: Double) throws {
         let diaryContext = Diary(context: context)
         
-        diaryContext.content = diary.content
-        diaryContext.date = diary.date
+        diaryContext.content = content
+        diaryContext.date = date
         
         do {
             try context.save()

--- a/Diary/Model/PersistenceManager.swift
+++ b/Diary/Model/PersistenceManager.swift
@@ -56,4 +56,17 @@ final class PersistenceManager {
             throw error
         }
     }
+    
+    func updateContent(at diary: Diary, _ content: String?, _ date: Double) throws {
+        do {
+            let item = try context.existingObject(with: diary.objectID)
+            
+            item.setValue(content, forKey: "content")
+            item.setValue(date, forKey: "date")
+            
+            try context.save()
+        } catch {
+            throw error
+        }
+    }
 }

--- a/Diary/Model/PersistenceManager.swift
+++ b/Diary/Model/PersistenceManager.swift
@@ -1,0 +1,59 @@
+//
+//  PersistenceManager.swift
+//  Diary
+//
+//  Created by kaki, 레옹아범 on 2023/05/02.
+//
+
+import Foundation
+import CoreData
+
+final class PersistenceManager {
+    static var shared: PersistenceManager = PersistenceManager()
+    
+    lazy var persistentContainer: NSPersistentContainer = {
+       let container = NSPersistentContainer(name: "Diary")
+        container.loadPersistentStores { _, error in
+            if let error = error as NSError? {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        }
+        
+        return container
+    }()
+    var context: NSManagedObjectContext {
+        return self.persistentContainer.viewContext
+    }
+    
+    private init() { }
+    
+    // MARK: - Create
+    func createContent(with diary: Diary) throws {
+        let diaryContext = Diary(context: context)
+        
+        diaryContext.content = diary.content
+        diaryContext.date = diary.date
+        
+        do {
+            try context.save()
+        } catch {
+            throw error
+        }
+    }
+    
+    // MARK: - Read
+    func fetchContent() throws -> [Diary] {
+        let fetchRequest = NSFetchRequest<Diary>(entityName: "Diary")
+        let sort = NSSortDescriptor(key: "date", ascending: false)
+        
+        fetchRequest.sortDescriptors = [sort]
+        
+        do {
+            let diaryData = try context.fetch(fetchRequest)
+            
+            return diaryData
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Diary/Model/PersistenceManager.swift
+++ b/Diary/Model/PersistenceManager.swift
@@ -11,30 +11,23 @@ import CoreData
 final class PersistenceManager {
     static var shared: PersistenceManager = PersistenceManager()
     
-//    private let persistentContainer: NSPersistentContainer = {
-//       let container = NSPersistentContainer(name: "Diary")
-//        container.loadPersistentStores { _, error in
-//            if let error = error as NSError? {
-//                fatalError("Unresolved error \(error), \(error.userInfo)")
-//            }
-//        }
-//
-//        return container
-//    }()
-//    private var context: NSManagedObjectContext {
-//        return self.persistentContainer.viewContext
-//    }
+    private var container: NSPersistentContainer?
     
     private init() { }
     
     private func getContext(completion: @escaping (Result<NSManagedObjectContext, NSError>) -> Void) {
-        let container = NSPersistentContainer(name: "Diary")
-        container.loadPersistentStores { _, error in
-            if let error = error as NSError? {
-                completion(.failure(error))
+        guard let container = self.container else {
+            let container = NSPersistentContainer(name: "Diary")
+            container.loadPersistentStores { _, error in
+                if let error = error as NSError? {
+                    completion(.failure(error))
+                }
             }
+            
+            self.container = container
+            completion(.success(container.viewContext))
+            return
         }
-        
         completion(.success(container.viewContext))
     }
     
@@ -62,21 +55,6 @@ final class PersistenceManager {
                 completion(.failure(error))
             }
         }
-        
-//        guard let entity = NSEntityDescription.entity(forEntityName: "Diary", in: context) else {
-//            return nil
-//        }
-//
-//        let managedObject = NSManagedObject(entity: entity, insertInto: self.context)
-//
-//        managedObject.setValue(content, forKey: "content")
-//        managedObject.setValue(date, forKey: "date")
-//
-//        guard let diary = managedObject as? Diary else { return nil }
-//
-//        try context.save()
-//
-//        return diary
     }
     
     func fetchContent(completion: @escaping (Result<[Diary], Error>) -> Void) {
@@ -98,10 +76,6 @@ final class PersistenceManager {
                 completion(.failure(error))
             }
         }
-        
-//        let diaryData = try context.fetch(fetchRequest)
-//
-//        return diaryData
     }
     
     func updateContent(at diary: Diary, _ content: String?, completion: @escaping (Result<Void, Error>) -> Void) {
@@ -122,13 +96,6 @@ final class PersistenceManager {
                 completion(.failure(error))
             }
         }
-        
-        
-//        let item = try context.existingObject(with: diary.objectID)
-//
-//        item.setValue(content, forKey: "content")
-//
-//        try context.save()
     }
     
     func deleteContent(at diary: Diary, completion: @escaping (Result<Void, Error>) -> Void) {
@@ -149,11 +116,5 @@ final class PersistenceManager {
                 completion(.failure(error))
             }
         }
-        
-//        let item = try context.existingObject(with: diary.objectID)
-//        
-//        context.delete(item)
-//        
-//        try context.save()
     }
 }

--- a/Diary/Model/PersistenceManager.swift
+++ b/Diary/Model/PersistenceManager.swift
@@ -59,6 +59,7 @@ final class PersistenceManager {
         }
     }
     
+    // MARK: - Update
     func updateContent(at diary: Diary, _ content: String?, _ date: Double) throws {
         do {
             let item = try context.existingObject(with: diary.objectID)
@@ -66,6 +67,18 @@ final class PersistenceManager {
             item.setValue(content, forKey: "content")
             item.setValue(date, forKey: "date")
             
+            try context.save()
+        } catch {
+            throw error
+        }
+    }
+    
+    // MARK: - Delete
+    func deleteContent(at diary: Diary) throws {
+        do {
+            let item = try context.existingObject(with: diary.objectID)
+            
+            context.delete(item)
             try context.save()
         } catch {
             throw error

--- a/Diary/Model/PersistenceManager.swift
+++ b/Diary/Model/PersistenceManager.swift
@@ -11,63 +11,149 @@ import CoreData
 final class PersistenceManager {
     static var shared: PersistenceManager = PersistenceManager()
     
-    private let persistentContainer: NSPersistentContainer = {
-       let container = NSPersistentContainer(name: "Diary")
-        container.loadPersistentStores { _, error in
-            if let error = error as NSError? {
-                fatalError("Unresolved error \(error), \(error.userInfo)")
-            }
-        }
-        
-        return container
-    }()
-    private var context: NSManagedObjectContext {
-        return self.persistentContainer.viewContext
-    }
+//    private let persistentContainer: NSPersistentContainer = {
+//       let container = NSPersistentContainer(name: "Diary")
+//        container.loadPersistentStores { _, error in
+//            if let error = error as NSError? {
+//                fatalError("Unresolved error \(error), \(error.userInfo)")
+//            }
+//        }
+//
+//        return container
+//    }()
+//    private var context: NSManagedObjectContext {
+//        return self.persistentContainer.viewContext
+//    }
     
     private init() { }
     
-    func createContent(_ content: String?, _ date: Double) throws -> Diary? {
-        guard let entity = NSEntityDescription.entity(forEntityName: "Diary", in: context) else {
-            return nil
+    private func getContext(completion: @escaping (Result<NSManagedObjectContext, NSError>) -> Void) {
+        let container = NSPersistentContainer(name: "Diary")
+        container.loadPersistentStores { _, error in
+            if let error = error as NSError? {
+                completion(.failure(error))
+            }
         }
         
-        let managedObject = NSManagedObject(entity: entity, insertInto: self.context)
-        
-        managedObject.setValue(content, forKey: "content")
-        managedObject.setValue(date, forKey: "date")
-        
-        guard let diary = managedObject as? Diary else { return nil }
-        
-        try context.save()
-        
-        return diary
+        completion(.success(container.viewContext))
     }
     
-    func fetchContent() throws -> [Diary] {
+    func createContent(_ content: String?, _ date: Double, completion: @escaping (Result<Diary, Error>) -> Void) {
+        getContext { result in
+            switch result {
+            case .success(let context):
+                guard let entity = NSEntityDescription.entity(forEntityName: "Diary", in: context) else { return }
+                
+                let managedObject = NSManagedObject(entity: entity, insertInto: context)
+                
+                managedObject.setValue(content, forKey: "content")
+                managedObject.setValue(date, forKey: "date")
+                
+                guard let diary = managedObject as? Diary else { return }
+                
+                do {
+                    try context.save()
+                } catch {
+                    completion(.failure(error))
+                }
+                
+                completion(.success(diary))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+        
+//        guard let entity = NSEntityDescription.entity(forEntityName: "Diary", in: context) else {
+//            return nil
+//        }
+//
+//        let managedObject = NSManagedObject(entity: entity, insertInto: self.context)
+//
+//        managedObject.setValue(content, forKey: "content")
+//        managedObject.setValue(date, forKey: "date")
+//
+//        guard let diary = managedObject as? Diary else { return nil }
+//
+//        try context.save()
+//
+//        return diary
+    }
+    
+    func fetchContent(completion: @escaping (Result<[Diary], Error>) -> Void) {
         let fetchRequest = NSFetchRequest<Diary>(entityName: "Diary")
         let sort = NSSortDescriptor(key: "date", ascending: false)
         
         fetchRequest.sortDescriptors = [sort]
         
-        let diaryData = try context.fetch(fetchRequest)
+        getContext { result in
+            switch result {
+            case .success(let context):
+                do {
+                    let diaryData = try context.fetch(fetchRequest)
+                    completion(.success(diaryData))
+                } catch {
+                    completion(.failure(error))
+                }
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
         
-        return diaryData
+//        let diaryData = try context.fetch(fetchRequest)
+//
+//        return diaryData
     }
     
-    func updateContent(at diary: Diary, _ content: String?) throws {
-        let item = try context.existingObject(with: diary.objectID)
+    func updateContent(at diary: Diary, _ content: String?, completion: @escaping (Result<Void, Error>) -> Void) {
+        getContext { result in
+            switch result {
+            case .success(let context):
+                do {
+                    let item = try context.existingObject(with: diary.objectID)
+                    
+                    item.setValue(content, forKey: "content")
+                    
+                    try context.save()
+                    completion(.success(()))
+                } catch {
+                    completion(.failure(error))
+                }
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
         
-        item.setValue(content, forKey: "content")
         
-        try context.save()
+//        let item = try context.existingObject(with: diary.objectID)
+//
+//        item.setValue(content, forKey: "content")
+//
+//        try context.save()
     }
     
-    func deleteContent(at diary: Diary) throws {
-        let item = try context.existingObject(with: diary.objectID)
+    func deleteContent(at diary: Diary, completion: @escaping (Result<Void, Error>) -> Void) {
+        getContext { result in
+            switch result {
+            case .success(let context):
+                do {
+                    let item = try context.existingObject(with: diary.objectID)
+                    
+                    context.delete(item)
+                    
+                    try context.save()
+                    completion(.success(()))
+                } catch {
+                    completion(.failure(error))
+                }
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
         
-        context.delete(item)
-        
-        try context.save()
+//        let item = try context.existingObject(with: diary.objectID)
+//        
+//        context.delete(item)
+//        
+//        try context.save()
     }
 }

--- a/Diary/Model/PersistenceManager.swift
+++ b/Diary/Model/PersistenceManager.swift
@@ -11,7 +11,7 @@ import CoreData
 final class PersistenceManager {
     static var shared: PersistenceManager = PersistenceManager()
     
-    lazy var persistentContainer: NSPersistentContainer = {
+    private let persistentContainer: NSPersistentContainer = {
        let container = NSPersistentContainer(name: "Diary")
         container.loadPersistentStores { _, error in
             if let error = error as NSError? {
@@ -21,13 +21,12 @@ final class PersistenceManager {
         
         return container
     }()
-    var context: NSManagedObjectContext {
+    private var context: NSManagedObjectContext {
         return self.persistentContainer.viewContext
     }
     
     private init() { }
     
-    // MARK: - Create
     func createContent(_ content: String?, _ date: Double) throws -> Diary? {
         guard let entity = NSEntityDescription.entity(forEntityName: "Diary", in: context) else {
             return nil
@@ -49,7 +48,6 @@ final class PersistenceManager {
         }
     }
     
-    // MARK: - Read
     func fetchContent() throws -> [Diary] {
         let fetchRequest = NSFetchRequest<Diary>(entityName: "Diary")
         let sort = NSSortDescriptor(key: "date", ascending: false)
@@ -65,21 +63,17 @@ final class PersistenceManager {
         }
     }
     
-    // MARK: - Update
-    func updateContent(at diary: Diary, _ content: String?, _ date: Double) throws {
+    func updateContent(at diary: Diary, _ content: String?) throws {
         do {
             let item = try context.existingObject(with: diary.objectID)
             
             item.setValue(content, forKey: "content")
-            item.setValue(date, forKey: "date")
-            
             try context.save()
         } catch {
             throw error
         }
     }
     
-    // MARK: - Delete
     func deleteContent(at diary: Diary) throws {
         do {
             let item = try context.existingObject(with: diary.objectID)

--- a/Diary/Model/PersistenceManager.swift
+++ b/Diary/Model/PersistenceManager.swift
@@ -28,16 +28,22 @@ final class PersistenceManager {
     private init() { }
     
     // MARK: - Create
-    func createContent(_ content: String?, _ date: Double) throws -> Diary {
-        let diaryContext = Diary(context: context)
+    func createContent(_ content: String?, _ date: Double) throws -> Diary? {
+        guard let entity = NSEntityDescription.entity(forEntityName: "Diary", in: context) else {
+            return nil
+        }
         
-        diaryContext.content = content
-        diaryContext.date = date
+        let managedObject = NSManagedObject(entity: entity, insertInto: self.context)
+        
+        managedObject.setValue(content, forKey: "content")
+        managedObject.setValue(date, forKey: "date")
+        
+        guard let diary = managedObject as? Diary else { return nil }
         
         do {
             try context.save()
             
-            return diaryContext
+            return diary
         } catch {
             throw error
         }

--- a/Diary/Model/PersistenceManager.swift
+++ b/Diary/Model/PersistenceManager.swift
@@ -28,7 +28,7 @@ final class PersistenceManager {
     private init() { }
     
     // MARK: - Create
-    func createContent(_ content: String?, _ date: Double) throws {
+    func createContent(_ content: String?, _ date: Double) throws -> Diary {
         let diaryContext = Diary(context: context)
         
         diaryContext.content = content
@@ -36,6 +36,8 @@ final class PersistenceManager {
         
         do {
             try context.save()
+            
+            return diaryContext
         } catch {
             throw error
         }

--- a/Diary/View/DiaryInfoTableViewCell.swift
+++ b/Diary/View/DiaryInfoTableViewCell.swift
@@ -52,19 +52,27 @@ final class DiaryInfoTableViewCell: UITableViewCell {
     
     func configureLabel(item: Diary) {
         guard let content = item.content else { return }
+        
+        let (title, body) = parseContent(content)
+        titleLabel.text = title
+        dateLabel.text = Date.convertToDate(by: item.date)
+        bodyLabel.text = body
+    }
+    
+    private func parseContent(_ content: String) -> (String?, String?) {
         let parsingDiary = content.split(separator: "\n").map { String($0) }
         
         let titleIndex = parsingDiary.firstIndex { str in
             !str.replacingOccurrences(of: " ", with: "").isEmpty
         }
         
-        guard let titleIndex = titleIndex else { return }
+        guard let titleIndex = titleIndex else { return (nil, nil) }
         
+        let title = parsingDiary[titleIndex]
         let bodyIndex = titleIndex + 1
         let body = parsingDiary[bodyIndex...].map { String($0) }.joined(separator: "\n")
-        titleLabel.text = parsingDiary[titleIndex]
-        dateLabel.text = Date.convertToDate(by: item.date)
-        bodyLabel.text = body
+        
+        return (title, body)
     }
 }
 

--- a/Diary/View/DiaryInfoTableViewCell.swift
+++ b/Diary/View/DiaryInfoTableViewCell.swift
@@ -68,9 +68,9 @@ final class DiaryInfoTableViewCell: UITableViewCell {
         
         guard let titleIndex = titleIndex else { return (nil, nil) }
         
-        let title = parsingDiary[titleIndex]
+        let title = parsingDiary[safe: titleIndex]
         let bodyIndex = titleIndex + 1
-        let body = parsingDiary[bodyIndex...].map { String($0) }.joined(separator: "\n")
+        let body = parsingDiary[safe: bodyIndex...]?.map { String($0) }.joined(separator: "\n")
         
         return (title, body)
     }

--- a/Diary/View/DiaryInfoTableViewCell.swift
+++ b/Diary/View/DiaryInfoTableViewCell.swift
@@ -50,10 +50,21 @@ final class DiaryInfoTableViewCell: UITableViewCell {
         bodyLabel.text = nil
     }
     
-    func configureLabel(item: JsonDiary) {
-        titleLabel.text = item.title
+    func configureLabel(item: Diary) {
+        guard let content = item.content else { return }
+        let parsingDiary = content.split(separator: "\n").map { String($0) }
+        
+        let titleIndex = parsingDiary.firstIndex { str in
+            !str.replacingOccurrences(of: " ", with: "").isEmpty
+        }
+        
+        guard let titleIndex = titleIndex else { return }
+        
+        let bodyIndex = titleIndex + 1
+        let body = parsingDiary[bodyIndex...].map { String($0) }.joined(separator: "\n")
+        titleLabel.text = parsingDiary[titleIndex]
         dateLabel.text = Date.convertToDate(by: item.date)
-        bodyLabel.text = item.body
+        bodyLabel.text = body
     }
 }
 

--- a/Diary/View/DiaryInfoTableViewCell.swift
+++ b/Diary/View/DiaryInfoTableViewCell.swift
@@ -53,13 +53,13 @@ final class DiaryInfoTableViewCell: UITableViewCell {
     func configureLabel(item: Diary) {
         guard let content = item.content else { return }
         
-        let (title, body) = parseContent(content)
-        titleLabel.text = title
+        let parsedContent = parseContent(content)
+        titleLabel.text = parsedContent.title
         dateLabel.text = Date.convertToDate(by: item.date)
-        bodyLabel.text = body
+        bodyLabel.text = parsedContent.body
     }
     
-    private func parseContent(_ content: String) -> (String?, String?) {
+    private func parseContent(_ content: String) -> (title: String?, body: String?) {
         let parsingDiary = content.split(separator: "\n").map { String($0) }
         let titleIndex = parsingDiary.firstIndex { str in
             !str.replacingOccurrences(of: " ", with: "").isEmpty

--- a/Diary/View/DiaryInfoTableViewCell.swift
+++ b/Diary/View/DiaryInfoTableViewCell.swift
@@ -50,7 +50,7 @@ final class DiaryInfoTableViewCell: UITableViewCell {
         bodyLabel.text = nil
     }
     
-    func configureLabel(item: Diary) {
+    func configureLabel(item: JsonDiary) {
         titleLabel.text = item.title
         dateLabel.text = Date.convertToDate(by: item.date)
         bodyLabel.text = item.body

--- a/Diary/View/DiaryInfoTableViewCell.swift
+++ b/Diary/View/DiaryInfoTableViewCell.swift
@@ -61,7 +61,6 @@ final class DiaryInfoTableViewCell: UITableViewCell {
     
     private func parseContent(_ content: String) -> (String?, String?) {
         let parsingDiary = content.split(separator: "\n").map { String($0) }
-        
         let titleIndex = parsingDiary.firstIndex { str in
             !str.replacingOccurrences(of: " ", with: "").isEmpty
         }

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@
 
 ## 1. 팀원
 
-|[레옹아범](https://github.com/fatherLeon)| [kaki](https://github.com/kak1x) |
+|[<img src="https://i.imgur.com/IOAJpzu.png" width="22"/> 레옹아범](https://github.com/fatherLeon)| [<img src="https://i.imgur.com/IOAJpzu.png" width="22"/> kaki](https://github.com/kak1x) |
 | :--------: | :--------: |
 |<img height="180px" src="https://raw.githubusercontent.com/Rhode-park/ios-rock-paper-scissors/step02/image/leonFather.jpeg">| <img height="180px" src="https://i.imgur.com/KkFB7j3.png"> |
 
 <br>
 
 ## 2. 타임라인
-#### 프로젝트 진행 기간 : 23.04.24 (월) ~ 23.04.28 (금)
+#### 프로젝트 진행 기간 : 23.04.24 (월) ~ 23.05.12 (금)
 
 | 날짜 | 타임라인 |
 | --- | --- |
@@ -32,6 +32,12 @@
 |23.04.26 (수)| DiaryDetailViewController 구현, 코드 컨벤션 수정 |
 |23.04.27 (목)| 전체 코드 리팩토링 및 Keyboard 화면 가림 방지 로직 변경 |
 |23.04.28 (금)| 코드 컨벤션 수정, README 작성 |
+|23.05.01 (월)| DiaryDetailViewController 리팩토링 |
+|23.05.02 (화)| CoreData CRUD 기능 구현 |
+|23.05.03 (수)| 테이블 뷰 셀 스와이프 시 삭제, 공유 버튼 구현 및 <br> 백그라운드 상태 코어데이터 오류 수정 |
+|23.05.04 (목)| 공유 버튼 클릭시 UIActivityView 구현 |
+|23.05.05 (금)| 코드 리팩토링 및 README 작성 |
+
 
 <br>
 
@@ -43,7 +49,9 @@
 Diary
     ├── .swiftlint.yml
     ├── Model
-    |    └── Diary
+    |    ├── JsonDiary
+    |    ├── DiaryState
+    |    └── PersistenceManager
     ├── View
     |    └── DiaryInfoTableViewCell
     ├── Controller
@@ -52,7 +60,8 @@ Diary
     ├── Etc
     |    ├── ReuseIdentifiable
     |    ├── ArrayExtension
-    |    └── DateExtension
+    |    ├── DateExtension
+    |    └── UIViewControllerExtention
     ├── AppDelegate
     ├── SceneDelegate
     ├── Assets
@@ -67,7 +76,9 @@ Diary
 
 |**일기장 초기 화면**|**기존 일기 조회 페이지**|**새로운 일기 작성 페이지**|
 |:-----:|:-----:|:-----:|
-| <img src = "https://user-images.githubusercontent.com/51234397/235034788-8dd64d8c-4567-4b78-b062-f31cb8d1bf86.gif" width = "300">|<img src = "https://user-images.githubusercontent.com/51234397/235034793-62ef393a-fe30-4887-b3b6-1fbb2c44a5e5.gif" width = "300"> |<img src = "https://user-images.githubusercontent.com/51234397/235034796-8a0f2b3d-cc71-4ff4-af6e-350c07718e21.gif" width = "300">|
+| <img src = "https://i.imgur.com/8HiNqbM.png" width = "300">|<img src = "https://user-images.githubusercontent.com/51234397/236361609-32ebeb57-4364-49c7-ab22-f01163acb247.gif" width = "300"> |<img src = "https://user-images.githubusercontent.com/51234397/236361616-3a9cc476-c0ed-4cb3-9d3d-b35230397b67.gif" width = "300">|
+|**새 일기 작성**|**일기 수정**|**일기 수정 후 Background 진입**|
+| <img src = "https://user-images.githubusercontent.com/51234397/236361619-fc1d7bf2-db00-4cff-acd2-92c97b1073b0.gif" width = "300">|<img src = "https://user-images.githubusercontent.com/51234397/236361623-a173b84f-e6d8-4d6c-b174-291340f5417f.gif" width = "300"> |<img src = "https://user-images.githubusercontent.com/51234397/236361626-f5daf472-d861-49b9-9097-528b1f3d14ef.gif" width = "300">|
 
 <br>
 


### PR DESCRIPTION
# 일기장 [STEP 2] kaki, 레옹아범
@havilog
안녕하세요 하비! kaki, 레옹아범 입니다🙂
STEP 2 구현이 완료되어 PR 드려요!! 잘 부탁드립니다🫡

## 구현내용

### Core Data CRUD
- PersistenceManager를 구현하였고 이곳에 CRUD 관련 기능을 구현해두었습니다.
- Read 기능 사용 시 날짜를 기준으로 하여 데이터를 정렬할 수 있게 구현하였습니다.
- Update 및 Delete 기능 사용 시 entity 객체의 objectID를 통해 데이터를 검색하여 이를 작업할 수 있도록 구현하였습니다.

### 백그라운드 진입 시 메모 저장
```swift
NotificationCenter.default.addObserver(self,
                                       selector: #selector(endEditingDiary),
                                       name: UIScene.didEnterBackgroundNotification,
                                       object: nil)
```
* `UIScene.didEnterBackgroundNotification`을 사용하여 백그라운드 진입 시 저장하도록 구현하였습니다.

### 셀 스와이프 시 공유와 삭제 기능 구현
```swift
func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
    //....
}
```
* UITableViewDelegate 메서드 중 하나를 사용하여 trailing부분에서 스와이프 할 경우 공유와 삭제가 표시되도록 구현하였습니다.
* 공유와 삭제의 경우 `UIContextualAction`를 통해 해당 기능 및 아이콘과 배경색을 수정하였습니다.
* 버튼 선택 이후 trailingSwipeAction이 종료될 수 있도록 각 버튼의 Action 핸들러 부분에 `completionHandler(true)`를 추가해주었습니다.

## 고민한 점

### 일기 생성 시 키보드가 자동으로 보이게 하는 시점
```swift
if state == .create {
    diaryTextView.becomeFirstResponder()
}
```
* 해당 로직을 어떠한 시점에서 사용해야 될지 고민했습니다.
* `viewDidLoad`, `viewWillAppear`, `viewDidAppear` 세 시점에서 해당 로직을 실행한 결과
* `viewDidLoad`와 `viewWillAppear`은 키보드가 빠르게 표시되지만 `Done`버튼이 존재하는 툴바가 늦게 표시되고 키보드도 부자연스럽게 표시되는 문제가 있었습니다.
* 따라서 `viewDidAppear` 시점에서 조금 늦게 표시되지만 자연스럽게 표시되도록 구현하였습니다.

### Update 시 날짜 업데이트 제외
- date를 업데이트 해주게 되면 옛날에 작성된 일기여도 수정 이후 가장 최신으로 sort 되어집니다.
- 메모가 아닌 일기장 앱이기 때문에 내용을 수정할때 date가 같이 수정되는 것이 부적절하다고 생각되었습니다.
- 이에 Update 시 content 부분만 업데이트 될 수 있도록 구현해주었습니다.

## 조언을 얻고 싶은 부분

### ActivityViewController present 시 콘솔창에 에러 출력
- 공유 버튼을 눌러 ActivityViewController를 띄워줄 경우 항상 에러가 출력되는 것을 볼 수 있었습니다.

```swift
2023-05-04 16:34:11.874055+0900 Diary[18117:1678977] [default] -imageForImageDescriptor: can do IO please adopt -imageForDescriptor: for IO free drawing or -prepareImageForDescriptor: if IO is allowed. (This will become a fault soon.)
2023-05-04 16:34:11.881150+0900 Diary[18117:1676763] [LayoutConstraints] Changing the translatesAutoresizingMaskIntoConstraints property of a UICollectionReusableView that is managed by a UICollectionView is not supported, and will result in incorrect self-sizing. View: <_UIActivityContentFooterView: 0x159f39600; baseClass = UICollectionReusableView; frame = (16 244.333; 361 52); layer = <CALayer: 0x600001997680>>
2023-05-04 16:34:13.860259+0900 Diary[18117:1677413] [ShareSheet] connection invalidated
```

- 레이아웃 관련 에러는 ActivityView 안에 존재하는 CollectionView의 레이아웃 문제로 보이는데, 이를 따로 수정해 줄 방법을 찾을 수가 없었습니다.
- 나머지 오류 관련해서도 정보를 찾을 수가 없어서 이를 해결해주지 못했습니다.
- 혹시 참고할 자료나 어떤 식으로 해결해줄 수 있는지 하비의 조언을 듣고 싶어요!