### PR TITLE
일기장 [STEP 3] Andrew, Brody

### DIFF
--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		71BFDF272A0B2E7B00A04DE3 /* APIEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BFDF262A0B2E7B00A04DE3 /* APIEndpoint.swift */; };
 		71BFDF292A0B369200A04DE3 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BFDF282A0B369200A04DE3 /* HTTPMethod.swift */; };
 		71BFDF2B2A0BB21A00A04DE3 /* NetworkProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BFDF2A2A0BB21A00A04DE3 /* NetworkProvider.swift */; };
+		71BFDF2D2A0BC35A00A04DE3 /* WeatherInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BFDF2C2A0BC35A00A04DE3 /* WeatherInformation.swift */; };
 		71C280902A00A1F20035E6D0 /* Diary+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71C2808E2A00A1F20035E6D0 /* Diary+CoreDataClass.swift */; };
 		71C280912A00A1F20035E6D0 /* Diary+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71C2808F2A00A1F20035E6D0 /* Diary+CoreDataProperties.swift */; };
 		71C280932A00A7380035E6D0 /* ProcessViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71C280922A00A7380035E6D0 /* ProcessViewController.swift */; };
@@ -76,6 +77,7 @@
 		71BFDF262A0B2E7B00A04DE3 /* APIEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIEndpoint.swift; sourceTree = "<group>"; };
 		71BFDF282A0B369200A04DE3 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		71BFDF2A2A0BB21A00A04DE3 /* NetworkProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProvider.swift; sourceTree = "<group>"; };
+		71BFDF2C2A0BC35A00A04DE3 /* WeatherInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherInformation.swift; sourceTree = "<group>"; };
 		71C2808E2A00A1F20035E6D0 /* Diary+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Diary+CoreDataClass.swift"; sourceTree = "<group>"; };
 		71C2808F2A00A1F20035E6D0 /* Diary+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Diary+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		71C280922A00A7380035E6D0 /* ProcessViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessViewController.swift; sourceTree = "<group>"; };
@@ -199,8 +201,9 @@
 		62CF2C2A2A0BB7C500A37CBD /* Weather */ = {
 			isa = PBXGroup;
 			children = (
-				62CF2C2E2A0BBC9900A37CBD /* Response */,
 				62CF2C2B2A0BB80800A37CBD /* WeatherService.swift */,
+				71BFDF2C2A0BC35A00A04DE3 /* WeatherInformation.swift */,
+				62CF2C2E2A0BBC9900A37CBD /* Response */,
 			);
 			path = Weather;
 			sourceTree = "<group>";
@@ -422,6 +425,7 @@
 				62CF2C282A0BB5E500A37CBD /* DefaultNetworkProvider.swift in Sources */,
 				62CF2C192A08DF7600A37CBD /* CoreDataManagable.swift in Sources */,
 				62CF2C262A0BAB3400A37CBD /* NetworkError.swift in Sources */,
+				71BFDF2D2A0BC35A00A04DE3 /* WeatherInformation.swift in Sources */,
 				62D3D26329FFB61300C294FC /* CoreDataManager.swift in Sources */,
 				C739AE25284DF28600741E8F /* AppDelegate.swift in Sources */,
 				C739AE27284DF28600741E8F /* SceneDelegate.swift in Sources */,

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		62CF2C282A0BB5E500A37CBD /* DefaultNetworkProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CF2C272A0BB5E500A37CBD /* DefaultNetworkProvider.swift */; };
 		62CF2C2C2A0BB80800A37CBD /* WeatherService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CF2C2B2A0BB80800A37CBD /* WeatherService.swift */; };
 		62CF2C302A0BC10200A37CBD /* WeatherResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CF2C2F2A0BC10200A37CBD /* WeatherResponse.swift */; };
+		62CF2C332A0BCE6200A37CBD /* WeatherAPIInformationOwner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CF2C322A0BCE6200A37CBD /* WeatherAPIInformationOwner.swift */; };
 		62D3D26329FFB61300C294FC /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62D3D26229FFB61300C294FC /* CoreDataManager.swift */; };
 		715A682729F77CA300626385 /* DiaryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715A682629F77CA300626385 /* DiaryCell.swift */; };
 		7169BD242A08C5C30071D048 /* ArrayExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7169BD232A08C5C30071D048 /* ArrayExtension.swift */; };
@@ -67,6 +68,7 @@
 		62CF2C272A0BB5E500A37CBD /* DefaultNetworkProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultNetworkProvider.swift; sourceTree = "<group>"; };
 		62CF2C2B2A0BB80800A37CBD /* WeatherService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherService.swift; sourceTree = "<group>"; };
 		62CF2C2F2A0BC10200A37CBD /* WeatherResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherResponse.swift; sourceTree = "<group>"; };
+		62CF2C322A0BCE6200A37CBD /* WeatherAPIInformationOwner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherAPIInformationOwner.swift; sourceTree = "<group>"; };
 		62D3D26229FFB61300C294FC /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
 		715A682629F77CA300626385 /* DiaryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryCell.swift; sourceTree = "<group>"; };
 		7169BD232A08C5C30071D048 /* ArrayExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayExtension.swift; sourceTree = "<group>"; };
@@ -201,6 +203,7 @@
 		62CF2C2A2A0BB7C500A37CBD /* Weather */ = {
 			isa = PBXGroup;
 			children = (
+				62CF2C312A0BCE5500A37CBD /* Protocol */,
 				62CF2C2B2A0BB80800A37CBD /* WeatherService.swift */,
 				71BFDF2C2A0BC35A00A04DE3 /* WeatherInformation.swift */,
 				62CF2C2E2A0BBC9900A37CBD /* Response */,
@@ -214,6 +217,14 @@
 				62CF2C2F2A0BC10200A37CBD /* WeatherResponse.swift */,
 			);
 			path = Response;
+			sourceTree = "<group>";
+		};
+		62CF2C312A0BCE5500A37CBD /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				62CF2C322A0BCE6200A37CBD /* WeatherAPIInformationOwner.swift */,
+			);
+			path = Protocol;
 			sourceTree = "<group>";
 		};
 		62D3D26629FFBBF100C294FC /* CoreData */ = {
@@ -436,6 +447,7 @@
 				71C280932A00A7380035E6D0 /* ProcessViewController.swift in Sources */,
 				62CF2C2C2A0BB80800A37CBD /* WeatherService.swift in Sources */,
 				7169BD242A08C5C30071D048 /* ArrayExtension.swift in Sources */,
+				62CF2C332A0BCE6200A37CBD /* WeatherAPIInformationOwner.swift in Sources */,
 				C739AE2F284DF28600741E8F /* Diary.xcdatamodeld in Sources */,
 				621340D029FB658000B55ADE /* ReusableIdentifier.swift in Sources */,
 				719A35CF2A03DBD000158CCC /* CoreDataError.swift in Sources */,

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		62CF2C192A08DF7600A37CBD /* CoreDataManagable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CF2C182A08DF7600A37CBD /* CoreDataManagable.swift */; };
 		62CF2C1C2A08E09400A37CBD /* CoreDataManger+CoreDataManagable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CF2C1B2A08E09400A37CBD /* CoreDataManger+CoreDataManagable.swift */; };
 		62CF2C1F2A08E25100A37CBD /* MockCoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CF2C1E2A08E25100A37CBD /* MockCoreDataManager.swift */; };
+		62CF2C222A0B377600A37CBD /* DecodingUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CF2C212A0B377600A37CBD /* DecodingUtility.swift */; };
+		62CF2C242A0B37AF00A37CBD /* JSONDecodingUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CF2C232A0B37AF00A37CBD /* JSONDecodingUtility.swift */; };
 		62D3D26329FFB61300C294FC /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62D3D26229FFB61300C294FC /* CoreDataManager.swift */; };
 		715A682729F77CA300626385 /* DiaryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715A682629F77CA300626385 /* DiaryCell.swift */; };
 		7169BD242A08C5C30071D048 /* ArrayExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7169BD232A08C5C30071D048 /* ArrayExtension.swift */; };
@@ -21,6 +23,8 @@
 		719A35CF2A03DBD000158CCC /* CoreDataError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 719A35CE2A03DBD000158CCC /* CoreDataError.swift */; };
 		719A35D42A03E7EA00158CCC /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 719A35D62A03E7EA00158CCC /* Localizable.strings */; };
 		719A35DA2A03EBAA00158CCC /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 719A35D92A03EBAA00158CCC /* StringExtension.swift */; };
+		71BFDF272A0B2E7B00A04DE3 /* APIEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BFDF262A0B2E7B00A04DE3 /* APIEndpoint.swift */; };
+		71BFDF292A0B369200A04DE3 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BFDF282A0B369200A04DE3 /* HTTPMethod.swift */; };
 		71C280902A00A1F20035E6D0 /* Diary+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71C2808E2A00A1F20035E6D0 /* Diary+CoreDataClass.swift */; };
 		71C280912A00A1F20035E6D0 /* Diary+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71C2808F2A00A1F20035E6D0 /* Diary+CoreDataProperties.swift */; };
 		71C280932A00A7380035E6D0 /* ProcessViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71C280922A00A7380035E6D0 /* ProcessViewController.swift */; };
@@ -51,6 +55,8 @@
 		62CF2C182A08DF7600A37CBD /* CoreDataManagable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManagable.swift; sourceTree = "<group>"; };
 		62CF2C1B2A08E09400A37CBD /* CoreDataManger+CoreDataManagable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CoreDataManger+CoreDataManagable.swift"; sourceTree = "<group>"; };
 		62CF2C1E2A08E25100A37CBD /* MockCoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCoreDataManager.swift; sourceTree = "<group>"; };
+		62CF2C212A0B377600A37CBD /* DecodingUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodingUtility.swift; sourceTree = "<group>"; };
+		62CF2C232A0B37AF00A37CBD /* JSONDecodingUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecodingUtility.swift; sourceTree = "<group>"; };
 		62D3D26229FFB61300C294FC /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
 		715A682629F77CA300626385 /* DiaryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryCell.swift; sourceTree = "<group>"; };
 		7169BD232A08C5C30071D048 /* ArrayExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayExtension.swift; sourceTree = "<group>"; };
@@ -58,6 +64,8 @@
 		719A35CE2A03DBD000158CCC /* CoreDataError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataError.swift; sourceTree = "<group>"; };
 		719A35D52A03E7EA00158CCC /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		719A35D92A03EBAA00158CCC /* StringExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtension.swift; sourceTree = "<group>"; };
+		71BFDF262A0B2E7B00A04DE3 /* APIEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIEndpoint.swift; sourceTree = "<group>"; };
+		71BFDF282A0B369200A04DE3 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		71C2808E2A00A1F20035E6D0 /* Diary+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Diary+CoreDataClass.swift"; sourceTree = "<group>"; };
 		71C2808F2A00A1F20035E6D0 /* Diary+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Diary+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		71C280922A00A7380035E6D0 /* ProcessViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessViewController.swift; sourceTree = "<group>"; };
@@ -92,6 +100,7 @@
 		621340D129FB6C2900B55ADE /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				71BFDF242A0B2D5600A04DE3 /* Network */,
 				62D3D26629FFBBF100C294FC /* CoreData */,
 				71C2808E2A00A1F20035E6D0 /* Diary+CoreDataClass.swift */,
 				71C2808F2A00A1F20035E6D0 /* Diary+CoreDataProperties.swift */,
@@ -159,6 +168,15 @@
 			path = Mock;
 			sourceTree = "<group>";
 		};
+		62CF2C202A0B376700A37CBD /* Utility */ = {
+			isa = PBXGroup;
+			children = (
+				62CF2C212A0B377600A37CBD /* DecodingUtility.swift */,
+				62CF2C232A0B37AF00A37CBD /* JSONDecodingUtility.swift */,
+			);
+			path = Utility;
+			sourceTree = "<group>";
+		};
 		62D3D26629FFBBF100C294FC /* CoreData */ = {
 			isa = PBXGroup;
 			children = (
@@ -169,6 +187,15 @@
 				62CF2C182A08DF7600A37CBD /* CoreDataManagable.swift */,
 			);
 			path = CoreData;
+			sourceTree = "<group>";
+		};
+		71BFDF242A0B2D5600A04DE3 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				71BFDF262A0B2E7B00A04DE3 /* APIEndpoint.swift */,
+				71BFDF282A0B369200A04DE3 /* HTTPMethod.swift */,
+			);
+			path = Network;
 			sourceTree = "<group>";
 		};
 		C739AE18284DF28600741E8F = {
@@ -194,6 +221,7 @@
 		C739AE23284DF28600741E8F /* Diary */ = {
 			isa = PBXGroup;
 			children = (
+				62CF2C202A0B376700A37CBD /* Utility */,
 				621340D529FB6C7200B55ADE /* Extension */,
 				621340D429FB6C5200B55ADE /* Protocol */,
 				621340D329FB6C3400B55ADE /* Controller */,
@@ -342,9 +370,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				71BFDF292A0B369200A04DE3 /* HTTPMethod.swift in Sources */,
+				62CF2C222A0B377600A37CBD /* DecodingUtility.swift in Sources */,
 				71C280912A00A1F20035E6D0 /* Diary+CoreDataProperties.swift in Sources */,
+				71BFDF272A0B2E7B00A04DE3 /* APIEndpoint.swift in Sources */,
 				C739AE29284DF28600741E8F /* HomeDiaryController.swift in Sources */,
 				719A35DA2A03EBAA00158CCC /* StringExtension.swift in Sources */,
+				62CF2C242A0B37AF00A37CBD /* JSONDecodingUtility.swift in Sources */,
 				6288090A29F7B819006145DD /* DateFormatterExtension.swift in Sources */,
 				62CF2C192A08DF7600A37CBD /* CoreDataManagable.swift in Sources */,
 				62D3D26329FFB61300C294FC /* CoreDataManager.swift in Sources */,

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		719A35DA2A03EBAA00158CCC /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 719A35D92A03EBAA00158CCC /* StringExtension.swift */; };
 		71BFDF272A0B2E7B00A04DE3 /* APIEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BFDF262A0B2E7B00A04DE3 /* APIEndpoint.swift */; };
 		71BFDF292A0B369200A04DE3 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BFDF282A0B369200A04DE3 /* HTTPMethod.swift */; };
+		71BFDF2B2A0BB21A00A04DE3 /* NetworkProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BFDF2A2A0BB21A00A04DE3 /* NetworkProvider.swift */; };
 		71C280902A00A1F20035E6D0 /* Diary+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71C2808E2A00A1F20035E6D0 /* Diary+CoreDataClass.swift */; };
 		71C280912A00A1F20035E6D0 /* Diary+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71C2808F2A00A1F20035E6D0 /* Diary+CoreDataProperties.swift */; };
 		71C280932A00A7380035E6D0 /* ProcessViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71C280922A00A7380035E6D0 /* ProcessViewController.swift */; };
@@ -68,6 +69,7 @@
 		719A35D92A03EBAA00158CCC /* StringExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtension.swift; sourceTree = "<group>"; };
 		71BFDF262A0B2E7B00A04DE3 /* APIEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIEndpoint.swift; sourceTree = "<group>"; };
 		71BFDF282A0B369200A04DE3 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
+		71BFDF2A2A0BB21A00A04DE3 /* NetworkProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProvider.swift; sourceTree = "<group>"; };
 		71C2808E2A00A1F20035E6D0 /* Diary+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Diary+CoreDataClass.swift"; sourceTree = "<group>"; };
 		71C2808F2A00A1F20035E6D0 /* Diary+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Diary+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		71C280922A00A7380035E6D0 /* ProcessViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessViewController.swift; sourceTree = "<group>"; };
@@ -197,6 +199,7 @@
 				71BFDF262A0B2E7B00A04DE3 /* APIEndpoint.swift */,
 				71BFDF282A0B369200A04DE3 /* HTTPMethod.swift */,
 				62CF2C252A0BAB3400A37CBD /* NetworkError.swift */,
+				71BFDF2A2A0BB21A00A04DE3 /* NetworkProvider.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -377,6 +380,7 @@
 				62CF2C222A0B377600A37CBD /* DecodingUtility.swift in Sources */,
 				71C280912A00A1F20035E6D0 /* Diary+CoreDataProperties.swift in Sources */,
 				71BFDF272A0B2E7B00A04DE3 /* APIEndpoint.swift in Sources */,
+				71BFDF2B2A0BB21A00A04DE3 /* NetworkProvider.swift in Sources */,
 				C739AE29284DF28600741E8F /* HomeDiaryController.swift in Sources */,
 				719A35DA2A03EBAA00158CCC /* StringExtension.swift in Sources */,
 				62CF2C242A0B37AF00A37CBD /* JSONDecodingUtility.swift in Sources */,

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		62CF2C1F2A08E25100A37CBD /* MockCoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CF2C1E2A08E25100A37CBD /* MockCoreDataManager.swift */; };
 		62CF2C222A0B377600A37CBD /* DecodingUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CF2C212A0B377600A37CBD /* DecodingUtility.swift */; };
 		62CF2C242A0B37AF00A37CBD /* JSONDecodingUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CF2C232A0B37AF00A37CBD /* JSONDecodingUtility.swift */; };
+		62CF2C262A0BAB3400A37CBD /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CF2C252A0BAB3400A37CBD /* NetworkError.swift */; };
 		62D3D26329FFB61300C294FC /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62D3D26229FFB61300C294FC /* CoreDataManager.swift */; };
 		715A682729F77CA300626385 /* DiaryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715A682629F77CA300626385 /* DiaryCell.swift */; };
 		7169BD242A08C5C30071D048 /* ArrayExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7169BD232A08C5C30071D048 /* ArrayExtension.swift */; };
@@ -57,6 +58,7 @@
 		62CF2C1E2A08E25100A37CBD /* MockCoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCoreDataManager.swift; sourceTree = "<group>"; };
 		62CF2C212A0B377600A37CBD /* DecodingUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodingUtility.swift; sourceTree = "<group>"; };
 		62CF2C232A0B37AF00A37CBD /* JSONDecodingUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecodingUtility.swift; sourceTree = "<group>"; };
+		62CF2C252A0BAB3400A37CBD /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		62D3D26229FFB61300C294FC /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
 		715A682629F77CA300626385 /* DiaryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryCell.swift; sourceTree = "<group>"; };
 		7169BD232A08C5C30071D048 /* ArrayExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayExtension.swift; sourceTree = "<group>"; };
@@ -194,6 +196,7 @@
 			children = (
 				71BFDF262A0B2E7B00A04DE3 /* APIEndpoint.swift */,
 				71BFDF282A0B369200A04DE3 /* HTTPMethod.swift */,
+				62CF2C252A0BAB3400A37CBD /* NetworkError.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -379,6 +382,7 @@
 				62CF2C242A0B37AF00A37CBD /* JSONDecodingUtility.swift in Sources */,
 				6288090A29F7B819006145DD /* DateFormatterExtension.swift in Sources */,
 				62CF2C192A08DF7600A37CBD /* CoreDataManagable.swift in Sources */,
+				62CF2C262A0BAB3400A37CBD /* NetworkError.swift in Sources */,
 				62D3D26329FFB61300C294FC /* CoreDataManager.swift in Sources */,
 				C739AE25284DF28600741E8F /* AppDelegate.swift in Sources */,
 				C739AE27284DF28600741E8F /* SceneDelegate.swift in Sources */,

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		62CF2C2C2A0BB80800A37CBD /* WeatherService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CF2C2B2A0BB80800A37CBD /* WeatherService.swift */; };
 		62CF2C302A0BC10200A37CBD /* WeatherResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CF2C2F2A0BC10200A37CBD /* WeatherResponse.swift */; };
 		62CF2C332A0BCE6200A37CBD /* WeatherAPIInformationOwner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CF2C322A0BCE6200A37CBD /* WeatherAPIInformationOwner.swift */; };
+		62CF2C352A0BD5BB00A37CBD /* DefaultWeatherService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CF2C342A0BD5BB00A37CBD /* DefaultWeatherService.swift */; };
 		62D3D26329FFB61300C294FC /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62D3D26229FFB61300C294FC /* CoreDataManager.swift */; };
 		715A682729F77CA300626385 /* DiaryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715A682629F77CA300626385 /* DiaryCell.swift */; };
 		7169BD242A08C5C30071D048 /* ArrayExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7169BD232A08C5C30071D048 /* ArrayExtension.swift */; };
@@ -71,6 +72,7 @@
 		62CF2C2B2A0BB80800A37CBD /* WeatherService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherService.swift; sourceTree = "<group>"; };
 		62CF2C2F2A0BC10200A37CBD /* WeatherResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherResponse.swift; sourceTree = "<group>"; };
 		62CF2C322A0BCE6200A37CBD /* WeatherAPIInformationOwner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherAPIInformationOwner.swift; sourceTree = "<group>"; };
+		62CF2C342A0BD5BB00A37CBD /* DefaultWeatherService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultWeatherService.swift; sourceTree = "<group>"; };
 		62D3D26229FFB61300C294FC /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
 		715A682629F77CA300626385 /* DiaryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryCell.swift; sourceTree = "<group>"; };
 		7169BD232A08C5C30071D048 /* ArrayExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayExtension.swift; sourceTree = "<group>"; };
@@ -207,10 +209,11 @@
 		62CF2C2A2A0BB7C500A37CBD /* Weather */ = {
 			isa = PBXGroup;
 			children = (
+				62CF2C2B2A0BB80800A37CBD /* WeatherService.swift */,
+				62CF2C342A0BD5BB00A37CBD /* DefaultWeatherService.swift */,
+				71BFDF2C2A0BC35A00A04DE3 /* WeatherInformation.swift */,
 				71BFDF302A0BD0F000A04DE3 /* Endpoint */,
 				62CF2C312A0BCE5500A37CBD /* Protocol */,
-				62CF2C2B2A0BB80800A37CBD /* WeatherService.swift */,
-				71BFDF2C2A0BC35A00A04DE3 /* WeatherInformation.swift */,
 				62CF2C2E2A0BBC9900A37CBD /* Response */,
 			);
 			path = Weather;
@@ -441,6 +444,7 @@
 				62CF2C222A0B377600A37CBD /* DecodingUtility.swift in Sources */,
 				71C280912A00A1F20035E6D0 /* Diary+CoreDataProperties.swift in Sources */,
 				71BFDF272A0B2E7B00A04DE3 /* APIEndpoint.swift in Sources */,
+				62CF2C352A0BD5BB00A37CBD /* DefaultWeatherService.swift in Sources */,
 				71BFDF2B2A0BB21A00A04DE3 /* NetworkProvider.swift in Sources */,
 				62CF2C302A0BC10200A37CBD /* WeatherResponse.swift in Sources */,
 				C739AE29284DF28600741E8F /* HomeDiaryController.swift in Sources */,

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		62CF2C2F2A0BC10200A37CBD /* WeatherResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherResponse.swift; sourceTree = "<group>"; };
 		62CF2C322A0BCE6200A37CBD /* WeatherAPIInformationOwner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherAPIInformationOwner.swift; sourceTree = "<group>"; };
 		62CF2C342A0BD5BB00A37CBD /* DefaultWeatherService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultWeatherService.swift; sourceTree = "<group>"; };
+		62CF2C362A0CDB0800A37CBD /* Diary2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Diary2.xcdatamodel; sourceTree = "<group>"; };
 		62D3D26229FFB61300C294FC /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
 		715A682629F77CA300626385 /* DiaryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryCell.swift; sourceTree = "<group>"; };
 		7169BD232A08C5C30071D048 /* ArrayExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayExtension.swift; sourceTree = "<group>"; };
@@ -762,9 +763,10 @@
 		C739AE2D284DF28600741E8F /* Diary.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				62CF2C362A0CDB0800A37CBD /* Diary2.xcdatamodel */,
 				C739AE2E284DF28600741E8F /* Diary.xcdatamodel */,
 			);
-			currentVersion = C739AE2E284DF28600741E8F /* Diary.xcdatamodel */;
+			currentVersion = 62CF2C362A0CDB0800A37CBD /* Diary2.xcdatamodel */;
 			path = Diary.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		71C280902A00A1F20035E6D0 /* Diary+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71C2808E2A00A1F20035E6D0 /* Diary+CoreDataClass.swift */; };
 		71C280912A00A1F20035E6D0 /* Diary+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71C2808F2A00A1F20035E6D0 /* Diary+CoreDataProperties.swift */; };
 		71C280932A00A7380035E6D0 /* ProcessViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71C280922A00A7380035E6D0 /* ProcessViewController.swift */; };
+		71E130DA2A0CB1ED004D01EE /* LocationDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71E130D92A0CB1ED004D01EE /* LocationDataManager.swift */; };
 		C739AE25284DF28600741E8F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C739AE24284DF28600741E8F /* AppDelegate.swift */; };
 		C739AE27284DF28600741E8F /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C739AE26284DF28600741E8F /* SceneDelegate.swift */; };
 		C739AE29284DF28600741E8F /* HomeDiaryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C739AE28284DF28600741E8F /* HomeDiaryController.swift */; };
@@ -89,6 +90,7 @@
 		71C2808E2A00A1F20035E6D0 /* Diary+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Diary+CoreDataClass.swift"; sourceTree = "<group>"; };
 		71C2808F2A00A1F20035E6D0 /* Diary+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Diary+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		71C280922A00A7380035E6D0 /* ProcessViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessViewController.swift; sourceTree = "<group>"; };
+		71E130D92A0CB1ED004D01EE /* LocationDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationDataManager.swift; sourceTree = "<group>"; };
 		C739AE21284DF28600741E8F /* Diary.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Diary.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C739AE24284DF28600741E8F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C739AE26284DF28600741E8F /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -120,6 +122,7 @@
 		621340D129FB6C2900B55ADE /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				71E130D92A0CB1ED004D01EE /* LocationDataManager.swift */,
 				62CF2C292A0BB7BB00A37CBD /* Service */,
 				71BFDF242A0B2D5600A04DE3 /* Network */,
 				62D3D26629FFBBF100C294FC /* CoreData */,
@@ -442,6 +445,7 @@
 			files = (
 				71BFDF292A0B369200A04DE3 /* HTTPMethod.swift in Sources */,
 				62CF2C222A0B377600A37CBD /* DecodingUtility.swift in Sources */,
+				71E130DA2A0CB1ED004D01EE /* LocationDataManager.swift in Sources */,
 				71C280912A00A1F20035E6D0 /* Diary+CoreDataProperties.swift in Sources */,
 				71BFDF272A0B2E7B00A04DE3 /* APIEndpoint.swift in Sources */,
 				62CF2C352A0BD5BB00A37CBD /* DefaultWeatherService.swift in Sources */,

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		62CF2C242A0B37AF00A37CBD /* JSONDecodingUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CF2C232A0B37AF00A37CBD /* JSONDecodingUtility.swift */; };
 		62CF2C262A0BAB3400A37CBD /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CF2C252A0BAB3400A37CBD /* NetworkError.swift */; };
 		62CF2C282A0BB5E500A37CBD /* DefaultNetworkProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CF2C272A0BB5E500A37CBD /* DefaultNetworkProvider.swift */; };
+		62CF2C2C2A0BB80800A37CBD /* WeatherService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CF2C2B2A0BB80800A37CBD /* WeatherService.swift */; };
+		62CF2C302A0BC10200A37CBD /* WeatherResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CF2C2F2A0BC10200A37CBD /* WeatherResponse.swift */; };
 		62D3D26329FFB61300C294FC /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62D3D26229FFB61300C294FC /* CoreDataManager.swift */; };
 		715A682729F77CA300626385 /* DiaryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715A682629F77CA300626385 /* DiaryCell.swift */; };
 		7169BD242A08C5C30071D048 /* ArrayExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7169BD232A08C5C30071D048 /* ArrayExtension.swift */; };
@@ -62,6 +64,8 @@
 		62CF2C232A0B37AF00A37CBD /* JSONDecodingUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecodingUtility.swift; sourceTree = "<group>"; };
 		62CF2C252A0BAB3400A37CBD /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		62CF2C272A0BB5E500A37CBD /* DefaultNetworkProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultNetworkProvider.swift; sourceTree = "<group>"; };
+		62CF2C2B2A0BB80800A37CBD /* WeatherService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherService.swift; sourceTree = "<group>"; };
+		62CF2C2F2A0BC10200A37CBD /* WeatherResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherResponse.swift; sourceTree = "<group>"; };
 		62D3D26229FFB61300C294FC /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
 		715A682629F77CA300626385 /* DiaryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryCell.swift; sourceTree = "<group>"; };
 		7169BD232A08C5C30071D048 /* ArrayExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayExtension.swift; sourceTree = "<group>"; };
@@ -106,6 +110,7 @@
 		621340D129FB6C2900B55ADE /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				62CF2C292A0BB7BB00A37CBD /* Service */,
 				71BFDF242A0B2D5600A04DE3 /* Network */,
 				62D3D26629FFBBF100C294FC /* CoreData */,
 				71C2808E2A00A1F20035E6D0 /* Diary+CoreDataClass.swift */,
@@ -181,6 +186,31 @@
 				62CF2C232A0B37AF00A37CBD /* JSONDecodingUtility.swift */,
 			);
 			path = Utility;
+			sourceTree = "<group>";
+		};
+		62CF2C292A0BB7BB00A37CBD /* Service */ = {
+			isa = PBXGroup;
+			children = (
+				62CF2C2A2A0BB7C500A37CBD /* Weather */,
+			);
+			path = Service;
+			sourceTree = "<group>";
+		};
+		62CF2C2A2A0BB7C500A37CBD /* Weather */ = {
+			isa = PBXGroup;
+			children = (
+				62CF2C2E2A0BBC9900A37CBD /* Response */,
+				62CF2C2B2A0BB80800A37CBD /* WeatherService.swift */,
+			);
+			path = Weather;
+			sourceTree = "<group>";
+		};
+		62CF2C2E2A0BBC9900A37CBD /* Response */ = {
+			isa = PBXGroup;
+			children = (
+				62CF2C2F2A0BC10200A37CBD /* WeatherResponse.swift */,
+			);
+			path = Response;
 			sourceTree = "<group>";
 		};
 		62D3D26629FFBBF100C294FC /* CoreData */ = {
@@ -384,6 +414,7 @@
 				71C280912A00A1F20035E6D0 /* Diary+CoreDataProperties.swift in Sources */,
 				71BFDF272A0B2E7B00A04DE3 /* APIEndpoint.swift in Sources */,
 				71BFDF2B2A0BB21A00A04DE3 /* NetworkProvider.swift in Sources */,
+				62CF2C302A0BC10200A37CBD /* WeatherResponse.swift in Sources */,
 				C739AE29284DF28600741E8F /* HomeDiaryController.swift in Sources */,
 				719A35DA2A03EBAA00158CCC /* StringExtension.swift in Sources */,
 				62CF2C242A0B37AF00A37CBD /* JSONDecodingUtility.swift in Sources */,
@@ -399,6 +430,7 @@
 				62CF2C1C2A08E09400A37CBD /* CoreDataManger+CoreDataManagable.swift in Sources */,
 				71C280902A00A1F20035E6D0 /* Diary+CoreDataClass.swift in Sources */,
 				71C280932A00A7380035E6D0 /* ProcessViewController.swift in Sources */,
+				62CF2C2C2A0BB80800A37CBD /* WeatherService.swift in Sources */,
 				7169BD242A08C5C30071D048 /* ArrayExtension.swift in Sources */,
 				C739AE2F284DF28600741E8F /* Diary.xcdatamodeld in Sources */,
 				621340D029FB658000B55ADE /* ReusableIdentifier.swift in Sources */,

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		62CF2C222A0B377600A37CBD /* DecodingUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CF2C212A0B377600A37CBD /* DecodingUtility.swift */; };
 		62CF2C242A0B37AF00A37CBD /* JSONDecodingUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CF2C232A0B37AF00A37CBD /* JSONDecodingUtility.swift */; };
 		62CF2C262A0BAB3400A37CBD /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CF2C252A0BAB3400A37CBD /* NetworkError.swift */; };
+		62CF2C282A0BB5E500A37CBD /* DefaultNetworkProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CF2C272A0BB5E500A37CBD /* DefaultNetworkProvider.swift */; };
 		62D3D26329FFB61300C294FC /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62D3D26229FFB61300C294FC /* CoreDataManager.swift */; };
 		715A682729F77CA300626385 /* DiaryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715A682629F77CA300626385 /* DiaryCell.swift */; };
 		7169BD242A08C5C30071D048 /* ArrayExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7169BD232A08C5C30071D048 /* ArrayExtension.swift */; };
@@ -60,6 +61,7 @@
 		62CF2C212A0B377600A37CBD /* DecodingUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodingUtility.swift; sourceTree = "<group>"; };
 		62CF2C232A0B37AF00A37CBD /* JSONDecodingUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecodingUtility.swift; sourceTree = "<group>"; };
 		62CF2C252A0BAB3400A37CBD /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
+		62CF2C272A0BB5E500A37CBD /* DefaultNetworkProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultNetworkProvider.swift; sourceTree = "<group>"; };
 		62D3D26229FFB61300C294FC /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
 		715A682629F77CA300626385 /* DiaryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryCell.swift; sourceTree = "<group>"; };
 		7169BD232A08C5C30071D048 /* ArrayExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayExtension.swift; sourceTree = "<group>"; };
@@ -200,6 +202,7 @@
 				71BFDF282A0B369200A04DE3 /* HTTPMethod.swift */,
 				62CF2C252A0BAB3400A37CBD /* NetworkError.swift */,
 				71BFDF2A2A0BB21A00A04DE3 /* NetworkProvider.swift */,
+				62CF2C272A0BB5E500A37CBD /* DefaultNetworkProvider.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -385,6 +388,7 @@
 				719A35DA2A03EBAA00158CCC /* StringExtension.swift in Sources */,
 				62CF2C242A0B37AF00A37CBD /* JSONDecodingUtility.swift in Sources */,
 				6288090A29F7B819006145DD /* DateFormatterExtension.swift in Sources */,
+				62CF2C282A0BB5E500A37CBD /* DefaultNetworkProvider.swift in Sources */,
 				62CF2C192A08DF7600A37CBD /* CoreDataManagable.swift in Sources */,
 				62CF2C262A0BAB3400A37CBD /* NetworkError.swift in Sources */,
 				62D3D26329FFB61300C294FC /* CoreDataManager.swift in Sources */,

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 		71BFDF292A0B369200A04DE3 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BFDF282A0B369200A04DE3 /* HTTPMethod.swift */; };
 		71BFDF2B2A0BB21A00A04DE3 /* NetworkProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BFDF2A2A0BB21A00A04DE3 /* NetworkProvider.swift */; };
 		71BFDF2D2A0BC35A00A04DE3 /* WeatherInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BFDF2C2A0BC35A00A04DE3 /* WeatherInformation.swift */; };
+		71BFDF2F2A0BD07800A04DE3 /* WeatherAPIEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BFDF2E2A0BD07800A04DE3 /* WeatherAPIEndpoint.swift */; };
+		71BFDF322A0BD16400A04DE3 /* WeatherInformationEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BFDF312A0BD16400A04DE3 /* WeatherInformationEndpoint.swift */; };
 		71C280902A00A1F20035E6D0 /* Diary+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71C2808E2A00A1F20035E6D0 /* Diary+CoreDataClass.swift */; };
 		71C280912A00A1F20035E6D0 /* Diary+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71C2808F2A00A1F20035E6D0 /* Diary+CoreDataProperties.swift */; };
 		71C280932A00A7380035E6D0 /* ProcessViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71C280922A00A7380035E6D0 /* ProcessViewController.swift */; };
@@ -80,6 +82,8 @@
 		71BFDF282A0B369200A04DE3 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		71BFDF2A2A0BB21A00A04DE3 /* NetworkProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProvider.swift; sourceTree = "<group>"; };
 		71BFDF2C2A0BC35A00A04DE3 /* WeatherInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherInformation.swift; sourceTree = "<group>"; };
+		71BFDF2E2A0BD07800A04DE3 /* WeatherAPIEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherAPIEndpoint.swift; sourceTree = "<group>"; };
+		71BFDF312A0BD16400A04DE3 /* WeatherInformationEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherInformationEndpoint.swift; sourceTree = "<group>"; };
 		71C2808E2A00A1F20035E6D0 /* Diary+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Diary+CoreDataClass.swift"; sourceTree = "<group>"; };
 		71C2808F2A00A1F20035E6D0 /* Diary+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Diary+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		71C280922A00A7380035E6D0 /* ProcessViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessViewController.swift; sourceTree = "<group>"; };
@@ -203,6 +207,7 @@
 		62CF2C2A2A0BB7C500A37CBD /* Weather */ = {
 			isa = PBXGroup;
 			children = (
+				71BFDF302A0BD0F000A04DE3 /* Endpoint */,
 				62CF2C312A0BCE5500A37CBD /* Protocol */,
 				62CF2C2B2A0BB80800A37CBD /* WeatherService.swift */,
 				71BFDF2C2A0BC35A00A04DE3 /* WeatherInformation.swift */,
@@ -223,6 +228,7 @@
 			isa = PBXGroup;
 			children = (
 				62CF2C322A0BCE6200A37CBD /* WeatherAPIInformationOwner.swift */,
+				71BFDF2E2A0BD07800A04DE3 /* WeatherAPIEndpoint.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -249,6 +255,14 @@
 				62CF2C272A0BB5E500A37CBD /* DefaultNetworkProvider.swift */,
 			);
 			path = Network;
+			sourceTree = "<group>";
+		};
+		71BFDF302A0BD0F000A04DE3 /* Endpoint */ = {
+			isa = PBXGroup;
+			children = (
+				71BFDF312A0BD16400A04DE3 /* WeatherInformationEndpoint.swift */,
+			);
+			path = Endpoint;
 			sourceTree = "<group>";
 		};
 		C739AE18284DF28600741E8F = {
@@ -437,11 +451,13 @@
 				62CF2C192A08DF7600A37CBD /* CoreDataManagable.swift in Sources */,
 				62CF2C262A0BAB3400A37CBD /* NetworkError.swift in Sources */,
 				71BFDF2D2A0BC35A00A04DE3 /* WeatherInformation.swift in Sources */,
+				71BFDF322A0BD16400A04DE3 /* WeatherInformationEndpoint.swift in Sources */,
 				62D3D26329FFB61300C294FC /* CoreDataManager.swift in Sources */,
 				C739AE25284DF28600741E8F /* AppDelegate.swift in Sources */,
 				C739AE27284DF28600741E8F /* SceneDelegate.swift in Sources */,
 				715A682729F77CA300626385 /* DiaryCell.swift in Sources */,
 				71714A3229FFBCB1006F3EA8 /* DiaryService.swift in Sources */,
+				71BFDF2F2A0BD07800A04DE3 /* WeatherAPIEndpoint.swift in Sources */,
 				62CF2C1C2A08E09400A37CBD /* CoreDataManger+CoreDataManagable.swift in Sources */,
 				71C280902A00A1F20035E6D0 /* Diary+CoreDataClass.swift in Sources */,
 				71C280932A00A7380035E6D0 /* ProcessViewController.swift in Sources */,

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		62CF2C302A0BC10200A37CBD /* WeatherResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CF2C2F2A0BC10200A37CBD /* WeatherResponse.swift */; };
 		62CF2C332A0BCE6200A37CBD /* WeatherAPIInformationOwner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CF2C322A0BCE6200A37CBD /* WeatherAPIInformationOwner.swift */; };
 		62CF2C352A0BD5BB00A37CBD /* DefaultWeatherService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CF2C342A0BD5BB00A37CBD /* DefaultWeatherService.swift */; };
+		62CF2C382A0DD3E700A37CBD /* ImageLoadUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CF2C372A0DD3E700A37CBD /* ImageLoadUtility.swift */; };
 		62D3D26329FFB61300C294FC /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62D3D26229FFB61300C294FC /* CoreDataManager.swift */; };
 		715A682729F77CA300626385 /* DiaryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715A682629F77CA300626385 /* DiaryCell.swift */; };
 		7169BD242A08C5C30071D048 /* ArrayExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7169BD232A08C5C30071D048 /* ArrayExtension.swift */; };
@@ -75,6 +76,7 @@
 		62CF2C322A0BCE6200A37CBD /* WeatherAPIInformationOwner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherAPIInformationOwner.swift; sourceTree = "<group>"; };
 		62CF2C342A0BD5BB00A37CBD /* DefaultWeatherService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultWeatherService.swift; sourceTree = "<group>"; };
 		62CF2C362A0CDB0800A37CBD /* Diary2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Diary2.xcdatamodel; sourceTree = "<group>"; };
+		62CF2C372A0DD3E700A37CBD /* ImageLoadUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoadUtility.swift; sourceTree = "<group>"; };
 		62D3D26229FFB61300C294FC /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
 		715A682629F77CA300626385 /* DiaryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryCell.swift; sourceTree = "<group>"; };
 		7169BD232A08C5C30071D048 /* ArrayExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayExtension.swift; sourceTree = "<group>"; };
@@ -198,6 +200,7 @@
 			children = (
 				62CF2C212A0B377600A37CBD /* DecodingUtility.swift */,
 				62CF2C232A0B37AF00A37CBD /* JSONDecodingUtility.swift */,
+				62CF2C372A0DD3E700A37CBD /* ImageLoadUtility.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -459,6 +462,7 @@
 				62CF2C282A0BB5E500A37CBD /* DefaultNetworkProvider.swift in Sources */,
 				62CF2C192A08DF7600A37CBD /* CoreDataManagable.swift in Sources */,
 				62CF2C262A0BAB3400A37CBD /* NetworkError.swift in Sources */,
+				62CF2C382A0DD3E700A37CBD /* ImageLoadUtility.swift in Sources */,
 				71BFDF2D2A0BC35A00A04DE3 /* WeatherInformation.swift in Sources */,
 				71BFDF322A0BD16400A04DE3 /* WeatherInformationEndpoint.swift in Sources */,
 				62D3D26329FFB61300C294FC /* CoreDataManager.swift in Sources */,

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		719A35CF2A03DBD000158CCC /* CoreDataError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 719A35CE2A03DBD000158CCC /* CoreDataError.swift */; };
 		719A35D42A03E7EA00158CCC /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 719A35D62A03E7EA00158CCC /* Localizable.strings */; };
 		719A35DA2A03EBAA00158CCC /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 719A35D92A03EBAA00158CCC /* StringExtension.swift */; };
+		71BC836A2A0DEBA50009EC75 /* WeatherImageEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BC83692A0DEBA50009EC75 /* WeatherImageEndpoint.swift */; };
 		71BFDF272A0B2E7B00A04DE3 /* APIEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BFDF262A0B2E7B00A04DE3 /* APIEndpoint.swift */; };
 		71BFDF292A0B369200A04DE3 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BFDF282A0B369200A04DE3 /* HTTPMethod.swift */; };
 		71BFDF2B2A0BB21A00A04DE3 /* NetworkProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BFDF2A2A0BB21A00A04DE3 /* NetworkProvider.swift */; };
@@ -84,6 +85,7 @@
 		719A35CE2A03DBD000158CCC /* CoreDataError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataError.swift; sourceTree = "<group>"; };
 		719A35D52A03E7EA00158CCC /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		719A35D92A03EBAA00158CCC /* StringExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtension.swift; sourceTree = "<group>"; };
+		71BC83692A0DEBA50009EC75 /* WeatherImageEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherImageEndpoint.swift; sourceTree = "<group>"; };
 		71BFDF262A0B2E7B00A04DE3 /* APIEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIEndpoint.swift; sourceTree = "<group>"; };
 		71BFDF282A0B369200A04DE3 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		71BFDF2A2A0BB21A00A04DE3 /* NetworkProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProvider.swift; sourceTree = "<group>"; };
@@ -271,6 +273,7 @@
 			isa = PBXGroup;
 			children = (
 				71BFDF312A0BD16400A04DE3 /* WeatherInformationEndpoint.swift */,
+				71BC83692A0DEBA50009EC75 /* WeatherImageEndpoint.swift */,
 			);
 			path = Endpoint;
 			sourceTree = "<group>";
@@ -448,6 +451,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				71BFDF292A0B369200A04DE3 /* HTTPMethod.swift in Sources */,
+				71BC836A2A0DEBA50009EC75 /* WeatherImageEndpoint.swift in Sources */,
 				62CF2C222A0B377600A37CBD /* DecodingUtility.swift in Sources */,
 				71E130DA2A0CB1ED004D01EE /* LocationDataManager.swift in Sources */,
 				71C280912A00A1F20035E6D0 /* Diary+CoreDataProperties.swift in Sources */,

--- a/Diary/Controller/HomeDiaryController.swift
+++ b/Diary/Controller/HomeDiaryController.swift
@@ -98,7 +98,6 @@ extension HomeDiaryController: UITableViewDataSource {
         ) as? DiaryCell else {
             return UITableViewCell()
         }
-        print(fetchedDiaryResultsController.object(at: indexPath).weather)
         let diary = fetchedDiaryResultsController.object(at: indexPath)
         cell.configureData(data: diary, localizedDateFormatter: localizedDateFormatter)
         

--- a/Diary/Controller/HomeDiaryController.swift
+++ b/Diary/Controller/HomeDiaryController.swift
@@ -37,16 +37,6 @@ final class HomeDiaryController: UIViewController {
         configureUI()
         setupFetchedResultsController()
         fetchDiaryData()
-        
-        let weatherService = DefaultWeatherService()
-        weatherService.fetchWeatherInformation(latitude: 42.33, longtitude: 34.33) { result in
-            switch result {
-            case .success(let info):
-                print(info)
-            case .failure(let error):
-                print(error)
-            }
-        }
     }
     
     private func setupTableView() {
@@ -108,7 +98,7 @@ extension HomeDiaryController: UITableViewDataSource {
         ) as? DiaryCell else {
             return UITableViewCell()
         }
-        
+        print(fetchedDiaryResultsController.object(at: indexPath).weather)
         let diary = fetchedDiaryResultsController.object(at: indexPath)
         cell.configureData(data: diary, localizedDateFormatter: localizedDateFormatter)
         

--- a/Diary/Controller/HomeDiaryController.swift
+++ b/Diary/Controller/HomeDiaryController.swift
@@ -77,7 +77,7 @@ final class HomeDiaryController: UIViewController {
         do {
             try fetchedDiaryResultsController.performFetch()
         } catch {
-            
+            print(error.localizedDescription)
         }
     }
     

--- a/Diary/Controller/HomeDiaryController.swift
+++ b/Diary/Controller/HomeDiaryController.swift
@@ -37,6 +37,16 @@ final class HomeDiaryController: UIViewController {
         configureUI()
         setupFetchedResultsController()
         fetchDiaryData()
+        
+        let weatherService = DefaultWeatherService()
+        weatherService.fetchWeatherInformation(latitude: 42.33, longtitude: 34.33) { result in
+            switch result {
+            case .success(let info):
+                print(info)
+            case .failure(let error):
+                print(error)
+            }
+        }
     }
     
     private func setupTableView() {

--- a/Diary/Controller/ProcessViewController.swift
+++ b/Diary/Controller/ProcessViewController.swift
@@ -27,7 +27,7 @@ final class ProcessViewController: UIViewController {
         }
     }
     
-    private typealias WeatherIconInformation = (weatherCondision: String, weatherIcon: String)
+    private typealias WeatherIconInformation = (weatherCondition: String, weatherIcon: String)
     private typealias DiaryInformation = (title: String, body: String)
     
     private let diaryTextView = UITextView()
@@ -157,7 +157,13 @@ final class ProcessViewController: UIViewController {
         if let diary {
             diaryService.update(id: diary.id, title: diaryInformation.title, body: diaryInformation.body)
         } else {
-            let result = diaryService.create(id: UUID(), title: diaryInformation.title, body: diaryInformation.body, weather: "", weatherIcon: "")
+            let result = diaryService.create(
+                id: UUID(),
+                title: diaryInformation.title,
+                body: diaryInformation.body,
+                weather: weatherInformation?.weatherCondition ?? "",
+                weatherIcon: weatherInformation?.weatherIcon ?? ""
+            )
             if case .success(let newDiary) = result {
                 diary = newDiary
             }
@@ -268,7 +274,7 @@ extension ProcessViewController: SettingAlertPresentable {
         ) { result in
             switch result {
             case .success(let info):
-                self.weatherInformation = (weatherCondision: info.main, weatherIcon: info.iconCode)
+                self.weatherInformation = (weatherCondition: info.main, weatherIcon: info.iconCode)
             case .failure(let error):
                 print(error)
             }

--- a/Diary/Controller/ProcessViewController.swift
+++ b/Diary/Controller/ProcessViewController.swift
@@ -236,3 +236,23 @@ final class ProcessViewController: UIViewController {
         diaryTextView.scrollIndicatorInsets = diaryTextView.contentInset
     }
 }
+
+extension ProcessViewController: SettingAlertPresentable {
+    func presentSystemSettingAlert() {
+        let requestLocationServiceAlert = UIAlertController(
+            title: "위치 정보 이용",
+            message: "위치 서비스를 사용할 수 없습니다.\n디바이스의 '설정 > 개인정보 보호'에서 위치 서비스를 켜주세요.",
+            preferredStyle: .alert
+        )
+        let goSetting = UIAlertAction(title: "설정으로 이동", style: .destructive) { _ in
+            if let appSetting = URL(string: UIApplication.openSettingsURLString) {
+                UIApplication.shared.open(appSetting)
+            }
+        }
+        let cancel = UIAlertAction(title: "취소", style: .default)
+        requestLocationServiceAlert.addAction(cancel)
+        requestLocationServiceAlert.addAction(goSetting)
+        
+        present(requestLocationServiceAlert, animated: true)
+    }
+}

--- a/Diary/Controller/ProcessViewController.swift
+++ b/Diary/Controller/ProcessViewController.swift
@@ -149,24 +149,30 @@ final class ProcessViewController: UIViewController {
             return
         }
         
-        if isDeleteDiary {
+        guard !isDeleteDiary else {
             self.navigationController?.popViewController(animated: true)
             return
         }
         
         if let diary {
-            diaryService.update(id: diary.id, title: diaryInformation.title, body: diaryInformation.body)
-        } else {
-            let result = diaryService.create(
-                id: UUID(),
+            diaryService.update(
+                id: diary.id,
                 title: diaryInformation.title,
-                body: diaryInformation.body,
-                weather: weatherInformation?.weatherCondition ?? "",
-                weatherIcon: weatherInformation?.weatherIcon ?? ""
+                body: diaryInformation.body
             )
-            if case .success(let newDiary) = result {
-                diary = newDiary
-            }
+            return
+        }
+        
+        let result = diaryService.create(
+            id: UUID(),
+            title: diaryInformation.title,
+            body: diaryInformation.body,
+            weather: weatherInformation?.weatherCondition ?? "",
+            weatherIcon: weatherInformation?.weatherIcon ?? ""
+        )
+        
+        if case .success(let newDiary) = result {
+            diary = newDiary
         }
     }
     
@@ -247,7 +253,9 @@ final class ProcessViewController: UIViewController {
     }
 }
 
-extension ProcessViewController: SettingAlertPresentable {
+// MARK: - LocationDataManagerProtocol
+
+extension ProcessViewController: LocationDataManagerProtocol {
     func presentSystemSettingAlert() {
         let requestLocationServiceAlert = UIAlertController(
             title: "위치 정보 이용",
@@ -270,13 +278,13 @@ extension ProcessViewController: SettingAlertPresentable {
         let weatherService = DefaultWeatherService()
         weatherService.fetchWeatherInformation(
             latitude: currentCoordinate.latitude,
-            longtitude: currentCoordinate.longitude
+            longitude: currentCoordinate.longitude
         ) { result in
             switch result {
             case .success(let info):
                 self.weatherInformation = (weatherCondition: info.main, weatherIcon: info.iconCode)
             case .failure(let error):
-                print(error)
+                print(error.localizedDescription)
             }
         }
     }

--- a/Diary/Controller/ProcessViewController.swift
+++ b/Diary/Controller/ProcessViewController.swift
@@ -5,6 +5,7 @@
 //  Created by Andrew, brody on 2023/04/25.
 //
 import UIKit
+import CoreLocation
 
 final class ProcessViewController: UIViewController {
     private enum LocalizationText {
@@ -48,7 +49,23 @@ final class ProcessViewController: UIViewController {
         configureNavigationItem()
         configureDiaryTextView()
         setUpNotification()
+//        setDiaryWeatherInformation(coordinate: )
     }
+    
+    func setDiaryWeatherInformation(coordinate: CLLocationCoordinate2D) {
+        let weatherService = DefaultWeatherService()
+        weatherService.fetchWeatherInformation(latitude: coordinate.latitude, longtitude: coordinate.longitude) { result in
+            switch result {
+            case .success(let info):
+                print(info)
+            case .failure(let error):
+                print(error)
+            }
+        }
+        
+    }
+    
+    
     
     override func viewDidAppear(_ animated: Bool) {
         diaryTextView.becomeFirstResponder()

--- a/Diary/Controller/ProcessViewController.swift
+++ b/Diary/Controller/ProcessViewController.swift
@@ -31,6 +31,7 @@ final class ProcessViewController: UIViewController {
     private var diary: Diary?
     private var isDeleteDiary: Bool = false
     private let diaryService: DiaryService
+    private let locationDataManager = LocationDataManager()
     
     init(diary: Diary? = nil, diaryService: DiaryService) {
         self.diary = diary

--- a/Diary/Controller/ProcessViewController.swift
+++ b/Diary/Controller/ProcessViewController.swift
@@ -27,12 +27,15 @@ final class ProcessViewController: UIViewController {
         }
     }
     
+    private typealias WeatherIconInformation = (weatherCondision: String, weatherIcon: String)
     private typealias DiaryInformation = (title: String, body: String)
+    
     private let diaryTextView = UITextView()
     private var diary: Diary?
     private var isDeleteDiary: Bool = false
     private let diaryService: DiaryService
     private let locationDataManager = LocationDataManager()
+    private var weatherInformation: WeatherIconInformation?
     
     init(diary: Diary? = nil, diaryService: DiaryService) {
         self.diary = diary
@@ -266,7 +269,7 @@ extension ProcessViewController: SettingAlertPresentable {
         ) { result in
             switch result {
             case .success(let info):
-                print(info)
+                self.weatherInformation = (weatherCondision: info.main, weatherIcon: info.iconCode)
             case .failure(let error):
                 print(error)
             }

--- a/Diary/Controller/ProcessViewController.swift
+++ b/Diary/Controller/ProcessViewController.swift
@@ -158,7 +158,6 @@ final class ProcessViewController: UIViewController {
             diaryService.update(id: diary.id, title: diaryInformation.title, body: diaryInformation.body)
         } else {
             let result = diaryService.create(id: UUID(), title: diaryInformation.title, body: diaryInformation.body, weather: "", weatherIcon: "")
-            
             if case .success(let newDiary) = result {
                 diary = newDiary
             }

--- a/Diary/Controller/ProcessViewController.swift
+++ b/Diary/Controller/ProcessViewController.swift
@@ -9,7 +9,8 @@ import CoreLocation
 
 final class ProcessViewController: UIViewController {
     private enum LocalizationText {
-        case delete, share, cancel, deleteAlertTitle, deleteAlertMessage
+        case delete, share, cancel, deleteAlertTitle, deleteAlertMessage,
+             settingAlertTitle, settingAlertMessage, locationMessage
         
         func localizd() -> String {
             switch self {
@@ -23,6 +24,12 @@ final class ProcessViewController: UIViewController {
                 return "진짜요?".localized()
             case .deleteAlertMessage:
                 return "정말로 삭제하시겠어요?".localized()
+            case .settingAlertTitle:
+                return "위치 정보 이용".localized()
+            case .settingAlertMessage:
+                return "설정으로 이동".localized()
+            case .locationMessage:
+                return "위치 서비스를 사용할 수 없습니다.\n디바이스의 '설정 > 개인정보 보호'에서 위치 서비스를 켜주세요.".localized()
             }
         }
     }
@@ -258,16 +265,16 @@ final class ProcessViewController: UIViewController {
 extension ProcessViewController: LocationDataManagerProtocol {
     func presentSystemSettingAlert() {
         let requestLocationServiceAlert = UIAlertController(
-            title: "위치 정보 이용",
-            message: "위치 서비스를 사용할 수 없습니다.\n디바이스의 '설정 > 개인정보 보호'에서 위치 서비스를 켜주세요.",
+            title: LocalizationText.settingAlertTitle.localizd() ,
+            message: LocalizationText.locationMessage.localizd(),
             preferredStyle: .alert
         )
-        let goSetting = UIAlertAction(title: "설정으로 이동", style: .destructive) { _ in
+        let goSetting = UIAlertAction(title: LocalizationText.settingAlertMessage.localizd(), style: .destructive) { _ in
             if let appSetting = URL(string: UIApplication.openSettingsURLString) {
                 UIApplication.shared.open(appSetting)
             }
         }
-        let cancel = UIAlertAction(title: "취소", style: .default)
+        let cancel = UIAlertAction(title: LocalizationText.cancel.localizd(), style: .default)
         requestLocationServiceAlert.addAction(cancel)
         requestLocationServiceAlert.addAction(goSetting)
         

--- a/Diary/Controller/ProcessViewController.swift
+++ b/Diary/Controller/ProcessViewController.swift
@@ -62,10 +62,7 @@ final class ProcessViewController: UIViewController {
                 print(error)
             }
         }
-        
     }
-    
-    
     
     override func viewDidAppear(_ animated: Bool) {
         diaryTextView.becomeFirstResponder()

--- a/Diary/Controller/ProcessViewController.swift
+++ b/Diary/Controller/ProcessViewController.swift
@@ -52,18 +52,6 @@ final class ProcessViewController: UIViewController {
 //        setDiaryWeatherInformation(coordinate: )
     }
     
-    func setDiaryWeatherInformation(coordinate: CLLocationCoordinate2D) {
-        let weatherService = DefaultWeatherService()
-        weatherService.fetchWeatherInformation(latitude: coordinate.latitude, longtitude: coordinate.longitude) { result in
-            switch result {
-            case .success(let info):
-                print(info)
-            case .failure(let error):
-                print(error)
-            }
-        }
-    }
-    
     override func viewDidAppear(_ animated: Bool) {
         diaryTextView.becomeFirstResponder()
     }
@@ -166,7 +154,7 @@ final class ProcessViewController: UIViewController {
         if let diary {
             diaryService.update(id: diary.id, title: diaryInformation.title, body: diaryInformation.body)
         } else {
-            let result = diaryService.create(id: UUID(), title: diaryInformation.title, body: diaryInformation.body)
+            let result = diaryService.create(id: UUID(), title: diaryInformation.title, body: diaryInformation.body, weather: )
             
             if case .success(let newDiary) = result {
                 diary = newDiary
@@ -268,5 +256,17 @@ extension ProcessViewController: SettingAlertPresentable {
         requestLocationServiceAlert.addAction(goSetting)
         
         present(requestLocationServiceAlert, animated: true)
+    }
+    
+    func setDiaryWeatherInformation(coordinate: CLLocationCoordinate2D) {
+        let weatherService = DefaultWeatherService()
+        weatherService.fetchWeatherInformation(latitude: coordinate.latitude, longtitude: coordinate.longitude) { result in
+            switch result {
+            case .success(let info):
+                print(info)
+            case .failure(let error):
+                print(error)
+            }
+        }
     }
 }

--- a/Diary/Controller/ProcessViewController.swift
+++ b/Diary/Controller/ProcessViewController.swift
@@ -49,7 +49,7 @@ final class ProcessViewController: UIViewController {
         configureNavigationItem()
         configureDiaryTextView()
         setUpNotification()
-//        setDiaryWeatherInformation(coordinate: )
+        locationDataManager.delegate = self
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -154,7 +154,7 @@ final class ProcessViewController: UIViewController {
         if let diary {
             diaryService.update(id: diary.id, title: diaryInformation.title, body: diaryInformation.body)
         } else {
-            let result = diaryService.create(id: UUID(), title: diaryInformation.title, body: diaryInformation.body, weather: )
+            let result = diaryService.create(id: UUID(), title: diaryInformation.title, body: diaryInformation.body, weather: "", weatherIcon: "")
             
             if case .success(let newDiary) = result {
                 diary = newDiary
@@ -258,9 +258,12 @@ extension ProcessViewController: SettingAlertPresentable {
         present(requestLocationServiceAlert, animated: true)
     }
     
-    func setDiaryWeatherInformation(coordinate: CLLocationCoordinate2D) {
+    func setDiaryWeatherInformation(with currentCoordinate: CLLocationCoordinate2D) {
         let weatherService = DefaultWeatherService()
-        weatherService.fetchWeatherInformation(latitude: coordinate.latitude, longtitude: coordinate.longitude) { result in
+        weatherService.fetchWeatherInformation(
+            latitude: currentCoordinate.latitude,
+            longtitude: currentCoordinate.longitude
+        ) { result in
             switch result {
             case .success(let info):
                 print(info)

--- a/Diary/Diary.xcdatamodeld/.xccurrentversion
+++ b/Diary/Diary.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Diary.xcdatamodel</string>
+	<string>Diary2.xcdatamodel</string>
 </dict>
 </plist>

--- a/Diary/Diary.xcdatamodeld/Diary2.xcdatamodel/contents
+++ b/Diary/Diary.xcdatamodeld/Diary2.xcdatamodel/contents
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21512" systemVersion="22C65" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Diary" representedClassName="Diary" syncable="YES">
+        <attribute name="body" attributeType="String"/>
+        <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="title" attributeType="String"/>
+    </entity>
+</model>

--- a/Diary/Diary.xcdatamodeld/Diary2.xcdatamodel/contents
+++ b/Diary/Diary.xcdatamodeld/Diary2.xcdatamodel/contents
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21512" systemVersion="22C65" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22E252" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Diary" representedClassName="Diary" syncable="YES">
         <attribute name="body" attributeType="String"/>
         <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="title" attributeType="String"/>
+        <attribute name="weather" optional="YES" attributeType="String"/>
+        <attribute name="weatherIcon" optional="YES" attributeType="String"/>
     </entity>
 </model>

--- a/Diary/Info.plist
+++ b/Diary/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>사용자의 위치를 기반으로 날씨 정보를 제공하기 위해 권한이 필요합니다.</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSExceptionDomains</key>

--- a/Diary/Info.plist
+++ b/Diary/Info.plist
@@ -2,6 +2,20 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict/>
+		<key>openweathermap.org</key>
+		<dict>
+			<key>NSExceptionAllowsInsecureHTTPLoads</key>
+			<string>YES</string>
+			<key>NSExceptionRequiresForwardSecrecy</key>
+			<false/>
+			<key>NSIncludesSubdomains</key>
+			<true/>
+		</dict>
+	</dict>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Diary/Model/CoreData/DiaryService.swift
+++ b/Diary/Model/CoreData/DiaryService.swift
@@ -20,12 +20,14 @@ final class DiaryService {
 
 extension DiaryService {
     @discardableResult
-    func create(id: UUID, title: String, body: String) -> Result<Diary, CoreDataError> {
+    func create(id: UUID, title: String, body: String, weather: String, weatherIcon: String) -> Result<Diary, CoreDataError> {
         let diary = Diary(context: managedContext)
         diary.id = id
         diary.title = title
         diary.body = body
         diary.createdAt = Date()
+        diary.weather = weather
+        diary.weatherIcon = weatherIcon
         
         let result = coreDataManager.saveContext()
         

--- a/Diary/Model/CoreData/Extension/CoreDataManger+CoreDataManagable.swift
+++ b/Diary/Model/CoreData/Extension/CoreDataManger+CoreDataManagable.swift
@@ -5,6 +5,4 @@
 //  Created by Andrew, brody on 2023/05/08.
 //
 
-extension CoreDataManager: CoreDataManagable {
-    
-}
+extension CoreDataManager: CoreDataManagable { }

--- a/Diary/Model/Diary+CoreDataProperties.swift
+++ b/Diary/Model/Diary+CoreDataProperties.swift
@@ -16,6 +16,9 @@ extension Diary {
     @NSManaged public var body: String
     @NSManaged public var createdAt: Date
     @NSManaged public var id: UUID
+    @NSManaged public var weather: String
+    @NSManaged public var weatherIcon: String
+    
 }
 
 extension Diary : Identifiable {

--- a/Diary/Model/LocationDataManager.swift
+++ b/Diary/Model/LocationDataManager.swift
@@ -7,8 +7,13 @@
 
 import CoreLocation
 
+protocol Presentable: AnyObject {
+    func presentSystemSettingAlert()
+}
+
 final class LocationDataManager: NSObject {
     private let locationManager = CLLocationManager()
+    weak var delegate: Presentable?
     
     override init() {
         super.init()
@@ -22,8 +27,6 @@ extension LocationDataManager: CLLocationManagerDelegate {
         if let coordinate = locations.last?.coordinate {
             print(coordinate)
         }
-        
-        locationManager.stopUpdatingLocation()
     }
     
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
@@ -32,12 +35,14 @@ extension LocationDataManager: CLLocationManagerDelegate {
     
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         switch manager.authorizationStatus {
-        case .authorizedWhenInUse, .authorizedAlways:
+        case .authorizedWhenInUse:
             locationManager.requestLocation()
         case .restricted, .denied:
-            break
+            delegate?.presentSystemSettingAlert()
         case .notDetermined:
             manager.requestWhenInUseAuthorization()
+        default:
+            break
         }
     }
 }

--- a/Diary/Model/LocationDataManager.swift
+++ b/Diary/Model/LocationDataManager.swift
@@ -1,0 +1,43 @@
+//
+//  LocationDataManager.swift
+//  Diary
+//
+//  Created by Andrew, brody on 2023/05/11.
+//
+
+import CoreLocation
+
+final class LocationDataManager: NSObject {
+    private let locationManager = CLLocationManager()
+    
+    override init() {
+        super.init()
+        locationManager.delegate = self
+    }
+}
+
+extension LocationDataManager: CLLocationManagerDelegate {
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        if let coordinate = locations.last?.coordinate {
+            print(coordinate)
+        }
+        
+        locationManager.stopUpdatingLocation()
+    }
+    
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        print(#function)
+    }
+    
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        switch manager.authorizationStatus {
+        case .authorizedWhenInUse, .authorizedAlways:
+            locationManager.requestLocation()
+        case .restricted, .denied:
+            break
+        case .notDetermined:
+            manager.requestWhenInUseAuthorization()
+        }
+    }
+    
+}

--- a/Diary/Model/LocationDataManager.swift
+++ b/Diary/Model/LocationDataManager.swift
@@ -9,6 +9,7 @@ import CoreLocation
 
 protocol SettingAlertPresentable: AnyObject {
     func presentSystemSettingAlert()
+    func setDiaryWeatherInformation(coordinate: CLLocationCoordinate2D)
 }
 
 final class LocationDataManager: NSObject {

--- a/Diary/Model/LocationDataManager.swift
+++ b/Diary/Model/LocationDataManager.swift
@@ -7,13 +7,13 @@
 
 import CoreLocation
 
-protocol Presentable: AnyObject {
+protocol SettingAlertPresentable: AnyObject {
     func presentSystemSettingAlert()
 }
 
 final class LocationDataManager: NSObject {
     private let locationManager = CLLocationManager()
-    weak var delegate: Presentable?
+    weak var delegate: SettingAlertPresentable?
     
     override init() {
         super.init()

--- a/Diary/Model/LocationDataManager.swift
+++ b/Diary/Model/LocationDataManager.swift
@@ -7,14 +7,14 @@
 
 import CoreLocation
 
-protocol SettingAlertPresentable: AnyObject {
+protocol LocationDataManagerProtocol: AnyObject {
     func presentSystemSettingAlert()
     func setDiaryWeatherInformation(with currentCoordinate: CLLocationCoordinate2D)
 }
 
 final class LocationDataManager: NSObject {
     private let locationManager = CLLocationManager()
-    weak var delegate: SettingAlertPresentable?
+    weak var delegate: LocationDataManagerProtocol?
     
     override init() {
         super.init()
@@ -31,7 +31,7 @@ extension LocationDataManager: CLLocationManagerDelegate {
     }
     
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
-        print(#function)
+        print(error.localizedDescription)
     }
     
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {

--- a/Diary/Model/LocationDataManager.swift
+++ b/Diary/Model/LocationDataManager.swift
@@ -13,6 +13,7 @@ final class LocationDataManager: NSObject {
     override init() {
         super.init()
         locationManager.delegate = self
+        locationManager.desiredAccuracy = kCLLocationAccuracyKilometer
     }
 }
 
@@ -39,5 +40,4 @@ extension LocationDataManager: CLLocationManagerDelegate {
             manager.requestWhenInUseAuthorization()
         }
     }
-    
 }

--- a/Diary/Model/LocationDataManager.swift
+++ b/Diary/Model/LocationDataManager.swift
@@ -9,7 +9,7 @@ import CoreLocation
 
 protocol SettingAlertPresentable: AnyObject {
     func presentSystemSettingAlert()
-    func setDiaryWeatherInformation(coordinate: CLLocationCoordinate2D)
+    func setDiaryWeatherInformation(with currentCoordinate: CLLocationCoordinate2D)
 }
 
 final class LocationDataManager: NSObject {
@@ -25,8 +25,8 @@ final class LocationDataManager: NSObject {
 
 extension LocationDataManager: CLLocationManagerDelegate {
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        if let coordinate = locations.last?.coordinate {
-            print(coordinate)
+        if let currentCoordinate = locations.last?.coordinate {
+            delegate?.setDiaryWeatherInformation(with: currentCoordinate)
         }
     }
     

--- a/Diary/Model/Network/APIEndpoint.swift
+++ b/Diary/Model/Network/APIEndpoint.swift
@@ -1,0 +1,12 @@
+//
+//  APIEndpoint.swift
+//  Diary
+//
+//  Created by Andrew on 2023/05/10.
+//
+
+import Foundation
+
+protocol APIEndpoint {
+    
+}

--- a/Diary/Model/Network/APIEndpoint.swift
+++ b/Diary/Model/Network/APIEndpoint.swift
@@ -8,5 +8,50 @@
 import Foundation
 
 protocol APIEndpoint {
+    associatedtype APIResponse: Decodable
     
+    var decoder: DecodingUtility { get }
+    var method: HTTPMethod { get }
+    var baseURLLiteral: String { get }
+    var path: String { get }
+    var url: URL? { get }
+    var headers: [String: String]? { get }
+    var queries: [String: String?] { get }
+}
+
+extension APIEndpoint {
+    var decoder: DecodingUtility {
+        return JSONDecodingUtility()
+    }
+    
+    var url: URL? {
+        guard let url = URL(string: baseURLLiteral)?.appendingPathComponent(path) else {
+            return nil
+        }
+        
+        var urlComponents = URLComponents(string: url.absoluteString)
+        let quries = self.queries.map { key, value in
+            URLQueryItem(name: key, value: value)
+        }
+        
+        urlComponents?.queryItems = quries
+        return urlComponents?.url
+    }
+    
+    var urlRequest: URLRequest? {
+        guard let url = self.url else {
+            return nil
+        }
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = self.method.rawValue
+        
+        if let headers = self.headers {
+            headers.forEach { key, value in
+                request.addValue(value, forHTTPHeaderField: key)
+            }
+        }
+        
+        return request
+    }
 }

--- a/Diary/Model/Network/APIEndpoint.swift
+++ b/Diary/Model/Network/APIEndpoint.swift
@@ -2,7 +2,7 @@
 //  APIEndpoint.swift
 //  Diary
 //
-//  Created by Andrew on 2023/05/10.
+//  Created by Andrew, brody on 2023/05/10.
 //
 
 import Foundation

--- a/Diary/Model/Network/APIEndpoint.swift
+++ b/Diary/Model/Network/APIEndpoint.swift
@@ -30,11 +30,11 @@ extension APIEndpoint {
         }
         
         var urlComponents = URLComponents(string: url.absoluteString)
-        let quries = self.queries.map { key, value in
+        let queries = self.queries.map { key, value in
             URLQueryItem(name: key, value: value)
         }
         
-        urlComponents?.queryItems = quries
+        urlComponents?.queryItems = queries
         return urlComponents?.url
     }
     

--- a/Diary/Model/Network/DefaultNetworkProvider.swift
+++ b/Diary/Model/Network/DefaultNetworkProvider.swift
@@ -1,0 +1,12 @@
+//
+//  DefaultNetworkProvider.swift
+//  Diary
+//
+//  Created by Andrew, brody on 2023/05/10.
+//
+
+import Foundation
+
+final class DefaultNetworkProvider: NetworkProvider {
+    let session: URLSession = URLSession.shared
+}

--- a/Diary/Model/Network/HTTPMethod.swift
+++ b/Diary/Model/Network/HTTPMethod.swift
@@ -2,7 +2,7 @@
 //  HTTPMethod.swift
 //  Diary
 //
-//  Created by Andrew on 2023/05/10.
+//  Created by Andrew, brody on 2023/05/10.
 //
 
 import Foundation

--- a/Diary/Model/Network/HTTPMethod.swift
+++ b/Diary/Model/Network/HTTPMethod.swift
@@ -1,0 +1,13 @@
+//
+//  HTTPMethod.swift
+//  Diary
+//
+//  Created by Andrew on 2023/05/10.
+//
+
+import Foundation
+
+enum HTTPMethod: String {
+    case get = "GET"
+    case post = "POST"
+}

--- a/Diary/Model/Network/NetworkError.swift
+++ b/Diary/Model/Network/NetworkError.swift
@@ -1,0 +1,17 @@
+//
+//  NetworkError.swift
+//  Diary
+//
+//  Created by Andrew, brody on 2023/05/10.
+//
+
+import Foundation
+
+enum NetworkError: Error {
+    case invalidRequest
+    case unknownError
+    case invalidResponse
+    case invalidStatusCode(code: Int, data: Data)
+    case invalidData
+    case parsingFailure(decodingError: DecodingError?, data: Data)
+}

--- a/Diary/Model/Network/NetworkProvider.swift
+++ b/Diary/Model/Network/NetworkProvider.swift
@@ -1,0 +1,57 @@
+//
+//  NetworkProvider.swift
+//  Diary
+//
+//  Created by Andrew on 2023/05/10.
+//
+
+import Foundation
+
+protocol NetworkProvider {
+    var session: URLSession { get }
+    func request<T: APIEndpoint>(
+        request: T,
+        completion: @escaping (Result<T.APIResponse, NetworkError>) -> Void )
+}
+
+extension NetworkProvider {
+    func request<T: APIEndpoint>(
+        _ request: T,
+        completion: @escaping (Result<T.APIResponse, NetworkError>) -> Void
+    ) {
+        guard let urlRequest = request.urlRequest else {
+            completion(.failure(.invalidRequest))
+            return
+        }
+        
+        let task = self.session.dataTask(with: urlRequest) { data, response, error in
+            if let error {
+                completion(.failure(.unknownError))
+            }
+            
+            guard let data else {
+                completion(.failure(.invalidData))
+                return
+            }
+            
+            guard let response = response as? HTTPURLResponse else {
+                completion(.failure(.invalidResponse))
+                return
+            }
+            
+            guard (200...299).contains(response.statusCode) else {
+                completion(.failure(.invalidStatusCode(code: response.statusCode, data: data)))
+                return
+            }
+            
+            do {
+                let decoded: T.APIResponse = try request.decoder.decode(data: data)
+                completion(.success(decoded))
+            } catch let error {
+                let decodingError = error as? DecodingError
+                completion(.failure(.parsingFailure(decodingError: decodingError, data: data)))
+            }
+        }
+        task.resume()
+    }
+}

--- a/Diary/Model/Network/NetworkProvider.swift
+++ b/Diary/Model/Network/NetworkProvider.swift
@@ -2,7 +2,7 @@
 //  NetworkProvider.swift
 //  Diary
 //
-//  Created by Andrew on 2023/05/10.
+//  Created by Andrew, brody on 2023/05/10.
 //
 
 import Foundation
@@ -10,7 +10,7 @@ import Foundation
 protocol NetworkProvider {
     var session: URLSession { get }
     func request<T: APIEndpoint>(
-        request: T,
+        _ request: T,
         completion: @escaping (Result<T.APIResponse, NetworkError>) -> Void )
 }
 

--- a/Diary/Model/Service/Weather/DefaultWeatherService.swift
+++ b/Diary/Model/Service/Weather/DefaultWeatherService.swift
@@ -1,0 +1,12 @@
+//
+//  DefaultWeatherService.swift
+//  Diary
+//
+//  Created by WeatherService on 2023/05/10.
+//
+
+import Foundation
+
+final class DefaultWeatherService: WeatherService {
+    let networkProvider: NetworkProvider = DefaultNetworkProvider()
+}

--- a/Diary/Model/Service/Weather/Endpoint/WeatherImageEndpoint.swift
+++ b/Diary/Model/Service/Weather/Endpoint/WeatherImageEndpoint.swift
@@ -16,7 +16,6 @@ struct WeatherImageEndpoint: WeatherAPIInformationOwner {
     
     var url: URL? {
         let weatherImageUrl = baseURLLiteral + path + iConCode + imageInfomation
-        print(weatherImageUrl)
         return URL(string: weatherImageUrl)
     }
 }

--- a/Diary/Model/Service/Weather/Endpoint/WeatherImageEndpoint.swift
+++ b/Diary/Model/Service/Weather/Endpoint/WeatherImageEndpoint.swift
@@ -1,0 +1,22 @@
+//
+//  WeatherImageEndpoint.swift
+//  Diary
+//
+//  Created by Andrew on 2023/05/12.
+//
+
+import Foundation
+
+struct WeatherImageEndpoint: WeatherAPIInformationOwner {
+    let baseURLLiteral = "https://openweathermap.org"
+    let method: HTTPMethod = .get
+    let path = "/img/wn/"
+    let iConCode: String
+    let imageInfomation = "@2x.png"
+    
+    var url: URL? {
+        let weatherImageUrl = baseURLLiteral + path + iConCode + imageInfomation
+        print(weatherImageUrl)
+        return URL(string: weatherImageUrl)
+    }
+}

--- a/Diary/Model/Service/Weather/Endpoint/WeatherInformationEndpoint.swift
+++ b/Diary/Model/Service/Weather/Endpoint/WeatherInformationEndpoint.swift
@@ -11,14 +11,14 @@ struct WeatherInformationEndpoint: WeatherAPIEndpoint {
     typealias APIResponse = WeatherResponse
     
     let latitude: String
-    let longtitude: String
+    let longitude: String
     let method: HTTPMethod = .get
     let path = "/data/2.5/weather"
-    var headers: [String : String]?
-    var queries: [String : String?] {
+    var headers: [String: String]?
+    var queries: [String: String?] {
         [
             "lat": self.latitude,
-            "lon": self.longtitude,
+            "lon": self.longitude,
             "appid": self.serviceKey
         ]
     }

--- a/Diary/Model/Service/Weather/Endpoint/WeatherInformationEndpoint.swift
+++ b/Diary/Model/Service/Weather/Endpoint/WeatherInformationEndpoint.swift
@@ -1,0 +1,25 @@
+//
+//  WeatherInformationEndpoint.swift
+//  Diary
+//
+//  Created by Andrew on 2023/05/10.
+//
+
+import Foundation
+
+struct WeatherInformationEndpoint: WeatherAPIEndpoint {
+    typealias APIResponse = WeatherResponse
+    
+    let latitude: String
+    let longtitude: String
+    let method: HTTPMethod = .get
+    let path = "/data/2.5/weather"
+    var headers: [String : String]?
+    var queries: [String : String?] {
+        [
+            "lat": self.latitude,
+            "lon": self.longtitude,
+            "appid": self.serviceKey
+        ]
+    }
+}

--- a/Diary/Model/Service/Weather/Protocol/WeatherAPIEndpoint.swift
+++ b/Diary/Model/Service/Weather/Protocol/WeatherAPIEndpoint.swift
@@ -1,0 +1,10 @@
+//
+//  WeatherAPIEndpoint.swift
+//  Diary
+//
+//  Created by Andrew on 2023/05/10.
+//
+
+import Foundation
+
+protocol WeatherAPIEndpoint: APIEndpoint, WeatherAPIInformationOwner { }

--- a/Diary/Model/Service/Weather/Protocol/WeatherAPIInformationOwner.swift
+++ b/Diary/Model/Service/Weather/Protocol/WeatherAPIInformationOwner.swift
@@ -18,6 +18,6 @@ extension WeatherAPIInformationOwner {
     }
     
     var baseURLLiteral: String {
-        return "http://www.openweathermap.org"
+        return "https://www.openweathermap.org"
     }
 }

--- a/Diary/Model/Service/Weather/Protocol/WeatherAPIInformationOwner.swift
+++ b/Diary/Model/Service/Weather/Protocol/WeatherAPIInformationOwner.swift
@@ -1,0 +1,23 @@
+//
+//  WeatherAPIInformationOwner.swift
+//  Diary
+//
+//  Created by Andrew, brody on 2023/05/10.
+//
+
+import Foundation
+
+protocol WeatherAPIInformationOwner {
+    var serviceKey: String { get }
+    var baseURLLiteral: String { get }
+}
+
+extension WeatherAPIInformationOwner {
+    var serviceKey: String {
+        return "98f9b1cde083ede28714691b438bedf0"
+    }
+    
+    var baseURLLiteral: String {
+        return "http://www.openweathermap.org"
+    }
+}

--- a/Diary/Model/Service/Weather/Protocol/WeatherAPIInformationOwner.swift
+++ b/Diary/Model/Service/Weather/Protocol/WeatherAPIInformationOwner.swift
@@ -18,6 +18,6 @@ extension WeatherAPIInformationOwner {
     }
     
     var baseURLLiteral: String {
-        return "https://www.openweathermap.org"
+        return "https://api.openweathermap.org"
     }
 }

--- a/Diary/Model/Service/Weather/Response/WeatherResponse.swift
+++ b/Diary/Model/Service/Weather/Response/WeatherResponse.swift
@@ -1,0 +1,62 @@
+//
+//  WeatherResponse.swift
+//  Diary
+//
+//  Created by Andrew, brody on 2023/05/10.
+//
+
+import Foundation
+
+struct WeatherResponse: Decodable {
+    let coord: Coord
+    let weather: [Weather]
+    let base: String
+    let main: Main
+    let visibility: Int
+    let wind: Wind
+    let clouds: Clouds
+    let dt: Int
+    let sys: Sys
+    let timezone, id: Int
+    let name: String
+    let cod: Int
+}
+
+struct Clouds: Decodable {
+    let all: Int
+}
+
+struct Coord: Decodable {
+    let lon, lat: Double
+}
+
+struct Main: Decodable {
+    let temp, feelsLike, tempMin, tempMax: Double
+    let pressure, humidity, seaLevel, grndLevel: Int
+
+    enum CodingKeys: String, CodingKey {
+        case temp
+        case feelsLike = "feels_like"
+        case tempMin = "temp_min"
+        case tempMax = "temp_max"
+        case pressure, humidity
+        case seaLevel = "sea_level"
+        case grndLevel = "grnd_level"
+    }
+}
+
+struct Sys: Decodable {
+    let country: String
+    let sunrise, sunset: Int
+}
+
+struct Weather: Decodable {
+    let id: Int
+    let main, description, icon: String
+}
+
+struct Wind: Decodable {
+    let speed: Double
+    let deg: Int
+    let gust: Double
+}

--- a/Diary/Model/Service/Weather/Response/WeatherResponse.swift
+++ b/Diary/Model/Service/Weather/Response/WeatherResponse.swift
@@ -23,6 +23,9 @@ struct Weather: Decodable {
 
 extension WeatherResponse {
     func convertToWeatherItems() -> WeatherInformation {
-        return WeatherInformation(main: self.weather[0].weatherCondition, iconCode: self.weather[0].icon)
+        return WeatherInformation(
+            main: self.weather[0].weatherCondition,
+            iconCode: self.weather[0].icon
+        )
     }
 }

--- a/Diary/Model/Service/Weather/Response/WeatherResponse.swift
+++ b/Diary/Model/Service/Weather/Response/WeatherResponse.swift
@@ -63,6 +63,6 @@ struct Wind: Decodable {
 
 extension WeatherResponse {
     func convertToWeatherItems() -> WeatherInformation {
-        return WeatherInformation(main: self.weather[0].main, icon: self.weather[0].icon)
+        return WeatherInformation(main: self.weather[0].main, iconCode: self.weather[0].icon)
     }
 }

--- a/Diary/Model/Service/Weather/Response/WeatherResponse.swift
+++ b/Diary/Model/Service/Weather/Response/WeatherResponse.swift
@@ -8,46 +8,7 @@
 import Foundation
 
 struct WeatherResponse: Decodable {
-    let coord: Coord
     let weather: [Weather]
-    let base: String
-    let main: Main
-    let visibility: Int
-    let wind: Wind
-    let clouds: Clouds
-    let dt: Int
-    let sys: Sys
-    let timezone, id: Int
-    let name: String
-    let cod: Int
-}
-
-struct Clouds: Decodable {
-    let all: Int
-}
-
-struct Coord: Decodable {
-    let lon, lat: Double
-}
-
-struct Main: Decodable {
-    let temp, feelsLike, tempMin, tempMax: Double
-    let pressure, humidity, seaLevel, grndLevel: Int
-
-    enum CodingKeys: String, CodingKey {
-        case temp
-        case feelsLike = "feels_like"
-        case tempMin = "temp_min"
-        case tempMax = "temp_max"
-        case pressure, humidity
-        case seaLevel = "sea_level"
-        case grndLevel = "grnd_level"
-    }
-}
-
-struct Sys: Decodable {
-    let country: String
-    let sunrise, sunset: Int
 }
 
 struct Weather: Decodable {
@@ -58,12 +19,6 @@ struct Weather: Decodable {
         case id, description, icon
         case weatherCondition  = "main"
     }
-}
-
-struct Wind: Decodable {
-    let speed: Double
-    let deg: Int
-    let gust: Double
 }
 
 extension WeatherResponse {

--- a/Diary/Model/Service/Weather/Response/WeatherResponse.swift
+++ b/Diary/Model/Service/Weather/Response/WeatherResponse.swift
@@ -52,7 +52,12 @@ struct Sys: Decodable {
 
 struct Weather: Decodable {
     let id: Int
-    let main, description, icon: String
+    let weatherCondition, description, icon: String
+    
+    enum CodingKeys: String, CodingKey {
+        case id, description, icon
+        case weatherCondition  = "main"
+    }
 }
 
 struct Wind: Decodable {
@@ -63,6 +68,6 @@ struct Wind: Decodable {
 
 extension WeatherResponse {
     func convertToWeatherItems() -> WeatherInformation {
-        return WeatherInformation(main: self.weather[0].main, iconCode: self.weather[0].icon)
+        return WeatherInformation(main: self.weather[0].weatherCondition, iconCode: self.weather[0].icon)
     }
 }

--- a/Diary/Model/Service/Weather/Response/WeatherResponse.swift
+++ b/Diary/Model/Service/Weather/Response/WeatherResponse.swift
@@ -60,3 +60,9 @@ struct Wind: Decodable {
     let deg: Int
     let gust: Double
 }
+
+extension WeatherResponse {
+    func convertToWeatherItems() -> WeatherInformation {
+        return WeatherInformation(main: self.weather[0].main, icon: self.weather[0].icon)
+    }
+}

--- a/Diary/Model/Service/Weather/WeatherInformation.swift
+++ b/Diary/Model/Service/Weather/WeatherInformation.swift
@@ -1,0 +1,13 @@
+//
+//  WeatherInformation.swift
+//  Diary
+//
+//  Created by Andrew, brody on 2023/05/10.
+//
+
+import Foundation
+
+struct WeatherInformation {
+    let main: String
+    let icon: String
+}

--- a/Diary/Model/Service/Weather/WeatherInformation.swift
+++ b/Diary/Model/Service/Weather/WeatherInformation.swift
@@ -9,5 +9,5 @@ import Foundation
 
 struct WeatherInformation {
     let main: String
-    let icon: String
+    let iconCode: String
 }

--- a/Diary/Model/Service/Weather/WeatherService.swift
+++ b/Diary/Model/Service/Weather/WeatherService.swift
@@ -1,0 +1,19 @@
+//
+//  WeatherService.swift
+//  Diary
+//
+//  Created by Andrew, brody on 2023/05/10.
+//
+
+//import Foundation
+//
+//protocol WeatherService {
+//    var networkProvider: NetworkProvider { get }
+//
+//    @discardableResult
+//    func fetchWeatherInformation(
+//        latitude: Double,
+//        longtitude: Double,
+//        completion: @escaping ((Result<Bool, NetworkProvider>) -> Void)
+//    )
+//}

--- a/Diary/Model/Service/Weather/WeatherService.swift
+++ b/Diary/Model/Service/Weather/WeatherService.swift
@@ -5,29 +5,30 @@
 //  Created by Andrew, brody on 2023/05/10.
 //
 
-//import Foundation
-//
-//protocol WeatherService {
-//    var networkProvider: NetworkProvider { get }
-//
-//    func fetchWeatherInformation(
-//        latitude: Double,
-//        longtitude: Double,
-//        completion: @escaping ((Result<WeatherResponse, NetworkError>) -> Void)
-//    )
-//
-//    func fetchWeatherImage(
-//        iconCode: String,
-//        completion: @escaping ((Result<Data, NetworkError>) -> Void)
-//    )
-//}
-//
-//extension WeatherService {
-//    func fetchWeatherInformation(
-//        latitude: Double,
-//        longtitude: Double,
-//        completion: @escaping ((Result<WeatherResponse, NetworkError>) -> Void)
-//    ) {
-//
-//    }
-//}
+import Foundation
+
+protocol WeatherService {
+    var networkProvider: NetworkProvider { get }
+
+    func fetchWeatherInformation(
+        latitude: Double,
+        longtitude: Double,
+        completion: @escaping ((Result<WeatherInformation, NetworkError>) -> Void)
+    )
+}
+
+extension WeatherService {
+    func fetchWeatherInformation(
+        latitude: Double,
+        longtitude: Double,
+        completion: @escaping ((Result<WeatherInformation, NetworkError>) -> Void)
+    ) {
+        let endPoint = WeatherInformationEndpoint(
+            latitude: String(latitude),
+            longtitude: String(longtitude)
+        )
+        return self.networkProvider.request(endPoint) { result in
+            completion(result.map { $0.convertToWeatherItems() })
+        }
+    }
+}

--- a/Diary/Model/Service/Weather/WeatherService.swift
+++ b/Diary/Model/Service/Weather/WeatherService.swift
@@ -10,10 +10,24 @@
 //protocol WeatherService {
 //    var networkProvider: NetworkProvider { get }
 //
-//    @discardableResult
 //    func fetchWeatherInformation(
 //        latitude: Double,
 //        longtitude: Double,
-//        completion: @escaping ((Result<Bool, NetworkProvider>) -> Void)
+//        completion: @escaping ((Result<WeatherResponse, NetworkError>) -> Void)
 //    )
+//
+//    func fetchWeatherImage(
+//        iconCode: String,
+//        completion: @escaping ((Result<Data, NetworkError>) -> Void)
+//    )
+//}
+//
+//extension WeatherService {
+//    func fetchWeatherInformation(
+//        latitude: Double,
+//        longtitude: Double,
+//        completion: @escaping ((Result<WeatherResponse, NetworkError>) -> Void)
+//    ) {
+//
+//    }
 //}

--- a/Diary/Model/Service/Weather/WeatherService.swift
+++ b/Diary/Model/Service/Weather/WeatherService.swift
@@ -12,7 +12,7 @@ protocol WeatherService {
 
     func fetchWeatherInformation(
         latitude: Double,
-        longtitude: Double,
+        longitude: Double,
         completion: @escaping ((Result<WeatherInformation, NetworkError>) -> Void)
     )
 }
@@ -20,12 +20,12 @@ protocol WeatherService {
 extension WeatherService {
     func fetchWeatherInformation(
         latitude: Double,
-        longtitude: Double,
+        longitude: Double,
         completion: @escaping ((Result<WeatherInformation, NetworkError>) -> Void)
     ) {
         let endPoint = WeatherInformationEndpoint(
             latitude: String(latitude),
-            longtitude: String(longtitude)
+            longitude: String(longitude)
         )
         return self.networkProvider.request(endPoint) { result in
             completion(result.map { $0.convertToWeatherItems() })

--- a/Diary/Utility/DecodingUtility.swift
+++ b/Diary/Utility/DecodingUtility.swift
@@ -1,0 +1,12 @@
+//
+//  DecodingUtility.swift
+//  Diary
+//
+//  Created by Andrew, brody on 2023/05/10.
+//
+
+import Foundation
+
+protocol DecodingUtility {
+    func decode<T: Decodable>(data: Data) throws -> T
+}

--- a/Diary/Utility/ImageLoadUtility.swift
+++ b/Diary/Utility/ImageLoadUtility.swift
@@ -1,0 +1,69 @@
+//
+//  ImageLoadUtility.swift
+//  Diary
+//
+//  Created by Andrew, brody on 2023/05/12.
+//
+
+import Foundation
+
+struct ImageUtility {
+    static let imageCache = URLCache(
+        memoryCapacity: 300 * 1024 * 1024,
+        diskCapacity: 1000 * 1024 * 1024,
+        directory: nil
+    )
+    
+    static func fetchImage(imageURL: URL, completionHandler: @escaping (Data) -> Void) {
+        let request = URLRequest(url: imageURL)
+        
+        self.loadImageFromCache(request: request) { result in
+            switch result {
+            case .success(let imageData):
+                completionHandler(imageData)
+            case .failure:
+                self.downloadImage(request: request) { imageData in
+                    completionHandler(imageData)
+                }
+            }
+        }
+    }
+    
+    private static func downloadImage(
+        request: URLRequest,
+        completionHandler: @escaping (Data) -> Void
+    ) {
+        let dataTask = URLSession.shared.dataTask(with: request) { data, response, _ in
+            guard let data else {
+                return
+            }
+            
+            guard let response = response as? HTTPURLResponse,
+                  (200...299).contains(response.statusCode) else {
+                return
+            }
+            
+            let cachedResponse = CachedURLResponse(
+                response: response,
+                data: data,
+                storagePolicy: .allowed
+            )
+        }
+        dataTask.resume()
+    }
+    
+    private static func loadImageFromCache(
+        request: URLRequest,
+        completionHandler: @escaping (Result<Data, CacheError>) -> Void
+    ) {
+        if let imageData = self.imageCache.cachedResponse(for: request)?.data {
+            completionHandler(.success(imageData))
+        } else {
+            completionHandler(.failure(.absentCashedImage))
+        }
+    }
+}
+
+enum CacheError: Error {
+    case absentCashedImage
+}

--- a/Diary/Utility/JSONDecodingUtility.swift
+++ b/Diary/Utility/JSONDecodingUtility.swift
@@ -1,0 +1,17 @@
+//
+//  JSONDecodingUtility.swift
+//  Diary
+//
+//  Created by Andrew, brody on 2023/05/10.
+//
+
+import Foundation
+
+class JSONDecodingUtility: DecodingUtility {
+    func decode<T: Decodable>(data: Data) throws -> T {
+        let decoder = JSONDecoder()
+        let result = try decoder.decode(T.self, from: data)
+        
+        return result
+    }
+}

--- a/Diary/Utility/JSONDecodingUtility.swift
+++ b/Diary/Utility/JSONDecodingUtility.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class JSONDecodingUtility: DecodingUtility {
+final class JSONDecodingUtility: DecodingUtility {
     func decode<T: Decodable>(data: Data) throws -> T {
         let decoder = JSONDecoder()
         let result = try decoder.decode(T.self, from: data)

--- a/Diary/View/DiaryCell.swift
+++ b/Diary/View/DiaryCell.swift
@@ -89,5 +89,15 @@ final class DiaryCell: UITableViewCell {
         titleLabel.text = data.title.isEmpty ? "새로운 일기장".localized() : data.title
         dateLabel.text = localizedDateFormatter.string(from: data.createdAt)
         previewLabel.text = data.body
+        
+        let imageUrl = URL(string: "https://openweathermap.org/img/wn/\(data.weatherIcon)@2x.png")
+        guard let imageUrl else {
+            return
+        }
+        ImageUtility.fetchImage(imageURL: imageUrl) { imageData in
+            DispatchQueue.main.async {
+                self.weatherImageView.image = UIImage(data: imageData)
+            }
+        }
     }
 }

--- a/Diary/View/DiaryCell.swift
+++ b/Diary/View/DiaryCell.swift
@@ -90,11 +90,13 @@ final class DiaryCell: UITableViewCell {
         dateLabel.text = localizedDateFormatter.string(from: data.createdAt)
         previewLabel.text = data.body
         
-        let imageUrl = URL(string: "https://openweathermap.org/img/wn/\(data.weatherIcon)@2x.png")
-        guard let imageUrl else {
+        let weatherImageUrl = WeatherImageEndpoint(iConCode: data.weatherIcon).url
+        
+        guard let weatherImageUrl else {
             return
         }
-        ImageUtility.fetchImage(imageURL: imageUrl) { imageData in
+        
+        ImageUtility.fetchImage(imageURL: weatherImageUrl) { imageData in
             DispatchQueue.main.async {
                 self.weatherImageView.image = UIImage(data: imageData)
             }

--- a/Diary/View/DiaryCell.swift
+++ b/Diary/View/DiaryCell.swift
@@ -23,6 +23,12 @@ final class DiaryCell: UITableViewCell {
         return label
     }()
     
+    private let weatherImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+    
     private let previewLabel = {
         let label = UILabel()
         label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
@@ -63,11 +69,15 @@ final class DiaryCell: UITableViewCell {
     private func configureUI() {
         contentView.addSubview(diaryStackView)
         contentStackView.addArrangedSubview(dateLabel)
+        contentStackView.addArrangedSubview(weatherImageView)
         contentStackView.addArrangedSubview(previewLabel)
         diaryStackView.addArrangedSubview(titleLabel)
         diaryStackView.addArrangedSubview(contentStackView)
         
         NSLayoutConstraint.activate([
+            weatherImageView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.05) ,
+            weatherImageView.heightAnchor.constraint(equalTo: weatherImageView.widthAnchor),
+            
             diaryStackView.topAnchor.constraint(equalTo: contentView.topAnchor),
             diaryStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             diaryStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 일기장 프로젝트 📓
 > CoreData를 활용해 일기장을 관리하는 앱
 > 
-> 프로젝트 기간: 2023.04.24 - 2023.05.13
+> 프로젝트 기간: 2023.04.24 - 2023.05.12
 
 <br/>
 
@@ -15,7 +15,9 @@
 - ✅ 테이블뷰에서 스와이프를 통한 삭제기능 구현
 - ✅ TextViewDelegate의 활용
 - ✅ NSFetchResultsController의 활용
-- ✅ Localization의 활용
+- ✅ 지역화 적용
+- ✅ CoreLocalization의 활용
+- ✅ CoreData Migration 적용
 
 ---
 ## 목차 📋
@@ -24,15 +26,14 @@
 3. [프로젝트 구조](#3-프로젝트-구조)
 4. [실행화면](#4-실행화면)
 5. [트러블 슈팅](#5-트러블-슈팅)
-6. [참고 자료](#6-참고-자료)
+6. [참고자료](#6-참고자료)
 
 ---
 ## 1. 팀원 소개
 |Brody|Andrew|
 |:--:|:--:|
-|<img src="https://avatars.githubusercontent.com/u/70146658?v=4" width="200">|<img src="https://github.com/hyemory/ios-exposition-universelle/blob/step2/images/Andrew.png?raw=true" width="200">|
+|<img src="https://avatars.githubusercontent.com/u/70146658?v=4" width="200">|<img src="https://github.com/Andrew-0411/ios-diary/assets/45560895/2872b119-d22b-46a7-85c4-d9e0c3dd6da8" width="250">|
 | [<img src="https://i.imgur.com/IOAJpzu.png" width="22"/> Github](https://github.com/seunghyunCheon) | [<img src="https://i.imgur.com/IOAJpzu.png" width="22"/> Github](https://github.com/Andrew-0411) |
-
 
 <br/>
 <br/>
@@ -53,42 +54,78 @@
 |2023-05-03(수)|Activity, Alert 기능 구현|
 |2023-05-04(목)|Localizable 기능 추가, 버그 수정|
 |2023-05-05(금)|README 작성, 코드컨벤션 정리|
+|2023-05-08(월)|CoreDataStack 테스트 코드 작성|
+|2023-05-09(화)|CoreLocation, CoreData Migration 학습|
+|2023-05-10(수)|WeatherAPI 네트워킹 객체 구성|
+|2023-05-11(목)|CoreLocation 객체 구성|
+|2023-05-12(금)|날씨 Icon UI에 적용, README 작성|
 
 </details>
-
 
 <br/>
 <br/>
 
 ## 3. 프로젝트 구조
 
-### 1️⃣ 폴더 구조
+### 폴더 구조
 ```
 ├── Diary
-│   ├── AppDelegate.swift
-│   ├── Model
-│   │   ├── CoreData
-│   │   │   ├── CoreDataError.swift
-│   │   │   ├── CoreDataFetchedResults.swift
-│   │   │   ├── CoreDataStack.swift
-│   │   │   └── DiaryService.swift
-│   │   ├── Diary+CoreDataClass.swift
-│   │   └── Diary+CoreDataProperties.swift
-│   │─── View
-│   │   └── DiaryCell.swift
-│   ├── Controller
-│   │   ├── HomeDiaryController.swift
-│   │   └── ProcessViewController.swift
 │   ├── Extension
+│   │   ├── ArrayExtension.swift
 │   │   ├── DateFormatterExtension.swift
 │   │   ├── ProcessViewController.swift
 │   │   └── StringExtension.swift
+│   ├── Model
+│   │   ├── CoreData
+│   │   │   ├── CoreDataError.swift
+│   │   │   ├── CoreDataManagable.swift
+│   │   │   ├── CoreDataManager.swift
+│   │   │   ├── DiaryService.swift
+│   │   │   └── Extension
+│   │   │       └── CoreDataManger+CoreDataManagable.swift
+│   │   ├── Diary+CoreDataClass.swift
+│   │   ├── Diary+CoreDataProperties.swift
+│   │   ├── LocationDataManager.swift
+│   │   ├── Network
+│   │   │   ├── APIEndpoint.swift
+│   │   │   ├── DefaultNetworkProvider.swift
+│   │   │   ├── HTTPMethod.swift
+│   │   │   ├── NetworkError.swift
+│   │   │   └── NetworkProvider.swift
+│   │   └── Service
+│   │       └── Weather
+│   │           ├── DefaultWeatherService.swift
+│   │           ├── Endpoint
+│   │           │   ├── WeatherImageEndpoint.swift
+│   │           │   └── WeatherInformationEndpoint.swift
+│   │           ├── Protocol
+│   │           │   ├── WeatherAPIEndpoint.swift
+│   │           │   └── WeatherAPIInformationOwner.swift
+│   │           ├── Response
+│   │           │   └── WeatherResponse.swift
+│   │           ├── WeatherInformation.swift
+│   │           └── WeatherService.swift
+│   │───View
+│   │   └── DiaryCell.swift
+│   ├── Controller
+│   │   ├── HomeDiaryController.swift
+│   │   └── ProcessViewController.swift
 │   ├── Protocol
 │   │   └── ReusableIdentifier.swift
-│   └── SceneDelegate.swift
-└── DiaryServiceTests
-        └──DiaryServiceTests.swift
+│   ├── SceneDelegate.swift
+│   ├── Utility
+│   │   ├── DecodingUtility.swift
+│   │   ├── ImageLoadUtility.swift
+│   │   └── JSONDecodingUtility.swift
+├── DiaryServiceTests
+│   ├── DiaryServiceTests.swift
+└───└── Mock
+         └── MockCoreDataManager.swift
 ```
+
+### UML</big></summary>
+
+![](https://github.com/seunghyunCheon/box-office/assets/70146658/1a3573da-6fc8-45e2-a8cb-e03ecdcca4d8)
 
 
 
@@ -101,9 +138,9 @@
 |:--:|:--:|:--:|
 |<img src="https://i.imgur.com/yQ6h5RN.gif" width="300">|<img src="https://i.imgur.com/yQ6h5RN.gif" width="300">|<img src="https://i.imgur.com/MX2eJmd.gif" width="300">|
 
-|Localization 적용|더보기->공유|더보기->삭제|
+|Localization 적용|더보기->공유, 삭제|위치 정보를 통한 날씨 표시|
 |:--:|:--:|:--:|
-|<img src="https://i.imgur.com/hHciA5D.gif" width="300">|<img src="https://i.imgur.com/R9QdmQT.gif" width="300">|<img src="https://i.imgur.com/uAPXXSv.gif" width="300">|
+|<img src="https://i.imgur.com/hHciA5D.gif" width="300">|<img src="https://github.com/yagom-academy/ios-diary/assets/45560895/cce6fab3-33ff-4e8d-a800-b4ca7169436b" width="300">|<img src="https://github.com/Andrew-0411/Study/assets/45560895/c648f1ec-ed3c-4b2c-9079-2e0881296579" width="300">
 
 
 <br/>
@@ -298,25 +335,30 @@ extension DiaryService {
 
 <br/>
 
-**🛠️ 개선해야 할 점**
 
+**🛠️ 개선해야 할 점**
+<br/>
 하지만 이 방법은 코어데이터에서 `Diary`에 관한 처리를 보기 편해졌을뿐 범용성에 대한 부분은 향상되지 않았습니다. 
 만약 10개의 엔티티가 존재한다면 10개의 Service를 만들어야 하는 상황이었던 것이죠.
 
 이 부분은 추후 여러 코어데이터를 범용성있게 사용하는 사례를 찾아보면서 제네릭과 protocol Extension을 이용해 개선할 예정입니다.
 
-<br/>
 
-## 6. 참고 자료
-- [Apple Developer: Layout](https://developer.apple.com/design/human-interface-guidelines/foundations/layout/)
+## 6. 참고자료
+- [Apple Docs: Layout](https://developer.apple.com/design/human-interface-guidelines/foundations/layout/)
 - [WWDC 2016: Making apps adaptive part 1](https://www.youtube.com/watch?v=hLkqt2g-450&ab_channel=anhpham)
 - [WWDC 2016: Making apps adaptive part 2](https://www.youtube.com/watch?v=s3utpBiRbB0&ab_channel=anhpham)
 - [WWDC 2018: UIKit: Apps for Every Size and Shape](https://developer.apple.com/videos/play/wwdc2018/235/)
 - [WWDC 2019: Making Apps with Core Data](https://developer.apple.com/videos/play/wwdc2019/230/)
-- [Apple Developer: DateFormatter](https://developer.apple.com/documentation/foundation/dateformatter)
-- [Apple Developer: UITextView](https://developer.apple.com/documentation/uikit/uitextview)
-- [Apple Developer: Core Data](https://developer.apple.com/documentation/coredata)
-- [Apple Developoer: UITextViewDelegate](https://developer.apple.com/documentation/uikit/uitextviewdelegate)
-- [Apple Developoer: UISwipeActionsConfiguration](https://developer.apple.com/documentation/uikit/uiswipeactionsconfiguration)
+- [Apple Docs: DateFormatter](https://developer.apple.com/documentation/foundation/dateformatter)
+- [Apple Docs: UITextView](https://developer.apple.com/documentation/uikit/uitextview)
+- [Apple Docs: Core Data](https://developer.apple.com/documentation/coredata)
+- [Apple Docs: UITextViewDelegate](https://developer.apple.com/documentation/uikit/uitextviewdelegate)
+- [Apple Docs: UISwipeActionsConfiguration](https://developer.apple.com/documentation/uikit/uiswipeactionsconfiguration)
 - [Apple Docs - adjustedcontentinset](https://developer.apple.com/documentation/uikit/uiscrollview/2902259-adjustedcontentinset)
 - [Apple Docs - contentInsetAdjustmentBehavior](https://developer.apple.com/documentation/uikit/uiscrollview/2902261-contentinsetadjustmentbehavior)
+- [Apple Docs - Core Location](https://developer.apple.com/documentation/corelocation)
+- [Apple Docs - Getting the current location of a device](https://developer.apple.com/documentation/corelocation/getting_the_current_location_of_a_device)
+- [Apple Docs - Configuring your app to use location services](https://developer.apple.com/documentation/corelocation/configuring_your_app_to_use_location_services)
+- [Apple Docs - Requesting authorization to use location services](https://developer.apple.com/documentation/corelocation/requesting_authorization_to_use_location_services)
+- [Apple Docs - Using Lightweight Migration](https://developer.apple.com/documentation/coredata/using_lightweight_migration)

--- a/README.md
+++ b/README.md
@@ -136,11 +136,11 @@
 ## 4. 실행화면
 |일기장 생성|일기장 수정|일기장 삭제|
 |:--:|:--:|:--:|
-|<img src="https://i.imgur.com/yQ6h5RN.gif" width="300">|<img src="https://i.imgur.com/yQ6h5RN.gif" width="300">|<img src="https://i.imgur.com/MX2eJmd.gif" width="300">|
+|<img src="https://i.imgur.com/yQ6h5RN.gif" width="200">|<img src="https://i.imgur.com/yQ6h5RN.gif" width="200">|<img src="https://i.imgur.com/MX2eJmd.gif" width="200">|
 
 |Localization 적용|더보기->공유, 삭제|위치 정보를 통한 날씨 표시|
 |:--:|:--:|:--:|
-|<img src="https://i.imgur.com/hHciA5D.gif" width="300">|<img src="https://github.com/yagom-academy/ios-diary/assets/45560895/cce6fab3-33ff-4e8d-a800-b4ca7169436b" width="300">|<img src="https://github.com/Andrew-0411/Study/assets/45560895/c648f1ec-ed3c-4b2c-9079-2e0881296579" width="300">
+|<img src="https://i.imgur.com/hHciA5D.gif" width="200">|<img src="https://github.com/yagom-academy/ios-diary/assets/45560895/cce6fab3-33ff-4e8d-a800-b4ca7169436b" width="200">|<img src="https://github.com/Andrew-0411/Study/assets/45560895/c648f1ec-ed3c-4b2c-9079-2e0881296579" width="200">
 
 
 <br/>

--- a/en.lproj/Localizable.strings
+++ b/en.lproj/Localizable.strings
@@ -17,3 +17,7 @@
 "취소" = "Cancel";
 "진짜요?" = "Really?";
 "정말로 삭제하시겠어요?" = "Are you sure you want to delete";
+"위치 정보 이용" = "Use of location information";
+"설정으로 이동" = "Move setting";
+"위치 서비스를 사용할 수 없습니다.\n디바이스의 '설정 > 개인정보 보호'에서 위치 서비스를 켜주세요." =
+"Location services are not available.\nTurn on location services in 'Settings > Privacy' on the device.";


### PR DESCRIPTION
@yim2627 안녕하세요 Jiseong! STEP3 PR 보내드립니다!

## 조언을 받고싶은 점

### LocationDataManager객체의 활용
`Location`에 대한 정보와 기능을 뷰컨트롤러에서 직접하기에는 뷰컨의 크기가 커지고, 역할이 많아진다고 생각하여 `LocationDataManager`라는 객체를 만들었습니다.

하지만 구현하다보니 `LocationDataManager`에서 뷰컨에 대한 `delegate`를 갖게 되면서 뷰컨에 의존하는 객체가 되었다고 생각이 들었습니다. 

예를 들어 `LocationDataManagerProtocol`은 `LocationDataManager`의 델리게이트 역할이 되는 객체가 해당 요구사항의 메서드들을 갖도록 만들었지만 사실 `setDiaryWeatherInformation`은 `ProcessViewController`에만 해당되는 메서드이고 만약 `Location`의 기능을 갖는 다른 뷰컨트롤러가 생긴다면 `setDiaryWeatherInformation`이 필요없지만 구현해야 하는 일이 발생할 것 같다고 생각했습니다.
```swift
protocol LocationDataManagerProtocol: AnyObject {
    func presentSystemSettingAlert()
    func setDiaryWeatherInformation(with currentCoordinate: CLLocationCoordinate2D)
}

final class LocationDataManager: NSObject {
    private let locationManager = CLLocationManager()
    weak var delegate: LocationDataManagerProtocol?
    
    override init() {
        super.init()
        locationManager.delegate = self
        locationManager.desiredAccuracy = kCLLocationAccuracyKilometer
    }
}
```

결국 이 객체를 다른 뷰컨에서 재사용하기에는 조금 무리가 있어보이는데 단순히 `ProcessViewController`의 책임을 줄였다는 점에서 사용할만한 가치가 있는지 궁금합니다! 
