### PR TITLE
일기장 [STEP 3] Rhode, 무리

### DIFF
--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -27,6 +27,9 @@
 		D0BAD8EF29F6705B0068E24B /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BAD8EE29F6705B0068E24B /* Date+.swift */; };
 		D0BAD8F129F770060068E24B /* DetailDiaryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BAD8F029F770060068E24B /* DetailDiaryViewController.swift */; };
 		D0C102712A0CAC280059F549 /* LocationDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C102702A0CAC280059F549 /* LocationDataManager.swift */; };
+		D0C102732A0CCF010059F549 /* DecodeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C102722A0CCF010059F549 /* DecodeManager.swift */; };
+		D0C102762A0CCFCB0059F549 /* DecodeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C102752A0CCFCB0059F549 /* DecodeError.swift */; };
+		D0C102792A0CD2060059F549 /* WeatherInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C102782A0CD2060059F549 /* WeatherInformation.swift */; };
 		D0ED6A3E29F6529E00C025E9 /* DiaryListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0ED6A3D29F6529E00C025E9 /* DiaryListCell.swift */; };
 /* End PBXBuildFile section */
 
@@ -53,6 +56,9 @@
 		D0BAD8EE29F6705B0068E24B /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		D0BAD8F029F770060068E24B /* DetailDiaryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailDiaryViewController.swift; sourceTree = "<group>"; };
 		D0C102702A0CAC280059F549 /* LocationDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationDataManager.swift; sourceTree = "<group>"; };
+		D0C102722A0CCF010059F549 /* DecodeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeManager.swift; sourceTree = "<group>"; };
+		D0C102752A0CCFCB0059F549 /* DecodeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeError.swift; sourceTree = "<group>"; };
+		D0C102782A0CD2060059F549 /* WeatherInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherInformation.swift; sourceTree = "<group>"; };
 		D0ED6A3D29F6529E00C025E9 /* DiaryListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -97,6 +103,7 @@
 		4B983AAB29F66DCA00190F50 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				D0C102772A0CD1A40059F549 /* DTO */,
 				4B983AA629F6650300190F50 /* Diary.swift */,
 				D00E414029FFABF0006A0F81 /* CoreDataManager.swift */,
 				D0C102702A0CAC280059F549 /* LocationDataManager.swift */,
@@ -152,6 +159,7 @@
 		C739AE23284DF28600741E8F /* Diary */ = {
 			isa = PBXGroup;
 			children = (
+				D0C102742A0CCF2A0059F549 /* Decode */,
 				4B656A6F2A0CBC0C005DA5FC /* Network */,
 				4B983AAA29F66DB500190F50 /* App */,
 				4B983AAB29F66DCA00190F50 /* Model */,
@@ -174,6 +182,23 @@
 				D00E414229FFC9C4006A0F81 /* String+.swift */,
 			);
 			path = Extension;
+			sourceTree = "<group>";
+		};
+		D0C102742A0CCF2A0059F549 /* Decode */ = {
+			isa = PBXGroup;
+			children = (
+				D0C102722A0CCF010059F549 /* DecodeManager.swift */,
+				D0C102752A0CCFCB0059F549 /* DecodeError.swift */,
+			);
+			path = Decode;
+			sourceTree = "<group>";
+		};
+		D0C102772A0CD1A40059F549 /* DTO */ = {
+			isa = PBXGroup;
+			children = (
+				D0C102782A0CD2060059F549 /* WeatherInformation.swift */,
+			);
+			path = DTO;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -271,6 +296,7 @@
 			files = (
 				C739AE29284DF28600741E8F /* DiaryListViewController.swift in Sources */,
 				D0ED6A3E29F6529E00C025E9 /* DiaryListCell.swift in Sources */,
+				D0C102732A0CCF010059F549 /* DecodeManager.swift in Sources */,
 				C739AE25284DF28600741E8F /* AppDelegate.swift in Sources */,
 				D074DF5629FF8E9000ADC9D1 /* Entity+CoreDataProperties.swift in Sources */,
 				4B656A6E2A0CBB4A005DA5FC /* NetworkManager.swift in Sources */,
@@ -284,8 +310,10 @@
 				D074DF5529FF8E9000ADC9D1 /* Entity+CoreDataClass.swift in Sources */,
 				D074DF5829FF98A700ADC9D1 /* Double+.swift in Sources */,
 				D00E414329FFC9C4006A0F81 /* String+.swift in Sources */,
+				D0C102792A0CD2060059F549 /* WeatherInformation.swift in Sources */,
 				4B656A742A0CC4A8005DA5FC /* NetworkError.swift in Sources */,
 				4B656A712A0CBC27005DA5FC /* URLRequestMaker.swift in Sources */,
+				D0C102762A0CCFCB0059F549 /* DecodeError.swift in Sources */,
 				D0BAD8EF29F6705B0068E24B /* Date+.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		D074DF5829FF98A700ADC9D1 /* Double+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D074DF5729FF98A700ADC9D1 /* Double+.swift */; };
 		D0BAD8EF29F6705B0068E24B /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BAD8EE29F6705B0068E24B /* Date+.swift */; };
 		D0BAD8F129F770060068E24B /* DetailDiaryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BAD8F029F770060068E24B /* DetailDiaryViewController.swift */; };
+		D0C102712A0CAC280059F549 /* LocationDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C102702A0CAC280059F549 /* LocationDataManager.swift */; };
 		D0ED6A3E29F6529E00C025E9 /* DiaryListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0ED6A3D29F6529E00C025E9 /* DiaryListCell.swift */; };
 /* End PBXBuildFile section */
 
@@ -45,6 +46,7 @@
 		D074DF5729FF98A700ADC9D1 /* Double+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+.swift"; sourceTree = "<group>"; };
 		D0BAD8EE29F6705B0068E24B /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		D0BAD8F029F770060068E24B /* DetailDiaryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailDiaryViewController.swift; sourceTree = "<group>"; };
+		D0C102702A0CAC280059F549 /* LocationDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationDataManager.swift; sourceTree = "<group>"; };
 		D0ED6A3D29F6529E00C025E9 /* DiaryListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -81,6 +83,7 @@
 			children = (
 				4B983AA629F6650300190F50 /* Diary.swift */,
 				D00E414029FFABF0006A0F81 /* CoreDataManager.swift */,
+				D0C102702A0CAC280059F549 /* LocationDataManager.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -253,6 +256,7 @@
 				D0ED6A3E29F6529E00C025E9 /* DiaryListCell.swift in Sources */,
 				C739AE25284DF28600741E8F /* AppDelegate.swift in Sources */,
 				D074DF5629FF8E9000ADC9D1 /* Entity+CoreDataProperties.swift in Sources */,
+				D0C102712A0CAC280059F549 /* LocationDataManager.swift in Sources */,
 				C739AE27284DF28600741E8F /* SceneDelegate.swift in Sources */,
 				4B116D142A020056001D63F0 /* ActionController.swift in Sources */,
 				D0BAD8F129F770060068E24B /* DetailDiaryViewController.swift in Sources */,

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		4B656A6D2A0CBB4A005DA5FC /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		4B656A702A0CBC27005DA5FC /* URLRequestMaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLRequestMaker.swift; sourceTree = "<group>"; };
 		4B656A732A0CC4A7005DA5FC /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
+		4B656A7D2A0D002F005DA5FC /* Diary v2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Diary v2.xcdatamodel"; sourceTree = "<group>"; };
 		4B983AA629F6650300190F50 /* Diary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Diary.swift; sourceTree = "<group>"; };
 		4BDCCCB029F76D8C00C79E4A /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		C739AE21284DF28600741E8F /* Diary.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Diary.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -529,9 +530,10 @@
 		C739AE2D284DF28600741E8F /* Diary.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				4B656A7D2A0D002F005DA5FC /* Diary v2.xcdatamodel */,
 				C739AE2E284DF28600741E8F /* Diary.xcdatamodel */,
 			);
-			currentVersion = C739AE2E284DF28600741E8F /* Diary.xcdatamodel */;
+			currentVersion = 4B656A7D2A0D002F005DA5FC /* Diary v2.xcdatamodel */;
 			path = Diary.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		4B656A712A0CBC27005DA5FC /* URLRequestMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B656A702A0CBC27005DA5FC /* URLRequestMaker.swift */; };
 		4B656A742A0CC4A8005DA5FC /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B656A732A0CC4A7005DA5FC /* NetworkError.swift */; };
 		4B983AA729F6650300190F50 /* Diary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B983AA629F6650300190F50 /* Diary.swift */; };
+		4BACE5582A0DFFFF006BFBAE /* CacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BACE5572A0DFFFF006BFBAE /* CacheManager.swift */; };
 		4BDCCCB129F76D8C00C79E4A /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 4BDCCCB029F76D8C00C79E4A /* .swiftlint.yml */; };
 		C739AE25284DF28600741E8F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C739AE24284DF28600741E8F /* AppDelegate.swift */; };
 		C739AE27284DF28600741E8F /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C739AE26284DF28600741E8F /* SceneDelegate.swift */; };
@@ -40,6 +41,7 @@
 		4B656A732A0CC4A7005DA5FC /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		4B656A7D2A0D002F005DA5FC /* Diary v2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Diary v2.xcdatamodel"; sourceTree = "<group>"; };
 		4B983AA629F6650300190F50 /* Diary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Diary.swift; sourceTree = "<group>"; };
+		4BACE5572A0DFFFF006BFBAE /* CacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheManager.swift; sourceTree = "<group>"; };
 		4BDCCCB029F76D8C00C79E4A /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		C739AE21284DF28600741E8F /* Diary.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Diary.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C739AE24284DF28600741E8F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -108,6 +110,7 @@
 				4B983AA629F6650300190F50 /* Diary.swift */,
 				D00E414029FFABF0006A0F81 /* CoreDataManager.swift */,
 				D0C102702A0CAC280059F549 /* LocationDataManager.swift */,
+				4BACE5572A0DFFFF006BFBAE /* CacheManager.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -301,6 +304,7 @@
 				C739AE25284DF28600741E8F /* AppDelegate.swift in Sources */,
 				D074DF5629FF8E9000ADC9D1 /* Entity+CoreDataProperties.swift in Sources */,
 				4B656A6E2A0CBB4A005DA5FC /* NetworkManager.swift in Sources */,
+				4BACE5582A0DFFFF006BFBAE /* CacheManager.swift in Sources */,
 				D0C102712A0CAC280059F549 /* LocationDataManager.swift in Sources */,
 				C739AE27284DF28600741E8F /* SceneDelegate.swift in Sources */,
 				4B116D142A020056001D63F0 /* ActionController.swift in Sources */,

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		4B116D142A020056001D63F0 /* ActionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B116D132A020056001D63F0 /* ActionController.swift */; };
+		4B656A6E2A0CBB4A005DA5FC /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B656A6D2A0CBB4A005DA5FC /* NetworkManager.swift */; };
+		4B656A712A0CBC27005DA5FC /* URLRequestMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B656A702A0CBC27005DA5FC /* URLRequestMaker.swift */; };
+		4B656A742A0CC4A8005DA5FC /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B656A732A0CC4A7005DA5FC /* NetworkError.swift */; };
 		4B983AA729F6650300190F50 /* Diary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B983AA629F6650300190F50 /* Diary.swift */; };
 		4BDCCCB129F76D8C00C79E4A /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 4BDCCCB029F76D8C00C79E4A /* .swiftlint.yml */; };
 		C739AE25284DF28600741E8F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C739AE24284DF28600741E8F /* AppDelegate.swift */; };
@@ -29,6 +32,9 @@
 
 /* Begin PBXFileReference section */
 		4B116D132A020056001D63F0 /* ActionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionController.swift; sourceTree = "<group>"; };
+		4B656A6D2A0CBB4A005DA5FC /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
+		4B656A702A0CBC27005DA5FC /* URLRequestMaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLRequestMaker.swift; sourceTree = "<group>"; };
+		4B656A732A0CC4A7005DA5FC /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		4B983AA629F6650300190F50 /* Diary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Diary.swift; sourceTree = "<group>"; };
 		4BDCCCB029F76D8C00C79E4A /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		C739AE21284DF28600741E8F /* Diary.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Diary.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -67,6 +73,16 @@
 				4B116D132A020056001D63F0 /* ActionController.swift */,
 			);
 			path = Utility;
+			sourceTree = "<group>";
+		};
+		4B656A6F2A0CBC0C005DA5FC /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				4B656A702A0CBC27005DA5FC /* URLRequestMaker.swift */,
+				4B656A6D2A0CBB4A005DA5FC /* NetworkManager.swift */,
+				4B656A732A0CC4A7005DA5FC /* NetworkError.swift */,
+			);
+			path = Network;
 			sourceTree = "<group>";
 		};
 		4B983AAA29F66DB500190F50 /* App */ = {
@@ -136,6 +152,7 @@
 		C739AE23284DF28600741E8F /* Diary */ = {
 			isa = PBXGroup;
 			children = (
+				4B656A6F2A0CBC0C005DA5FC /* Network */,
 				4B983AAA29F66DB500190F50 /* App */,
 				4B983AAB29F66DCA00190F50 /* Model */,
 				4B983AAC29F66DE900190F50 /* View */,
@@ -256,6 +273,7 @@
 				D0ED6A3E29F6529E00C025E9 /* DiaryListCell.swift in Sources */,
 				C739AE25284DF28600741E8F /* AppDelegate.swift in Sources */,
 				D074DF5629FF8E9000ADC9D1 /* Entity+CoreDataProperties.swift in Sources */,
+				4B656A6E2A0CBB4A005DA5FC /* NetworkManager.swift in Sources */,
 				D0C102712A0CAC280059F549 /* LocationDataManager.swift in Sources */,
 				C739AE27284DF28600741E8F /* SceneDelegate.swift in Sources */,
 				4B116D142A020056001D63F0 /* ActionController.swift in Sources */,
@@ -266,6 +284,8 @@
 				D074DF5529FF8E9000ADC9D1 /* Entity+CoreDataClass.swift in Sources */,
 				D074DF5829FF98A700ADC9D1 /* Double+.swift in Sources */,
 				D00E414329FFC9C4006A0F81 /* String+.swift in Sources */,
+				4B656A742A0CC4A8005DA5FC /* NetworkError.swift in Sources */,
+				4B656A712A0CBC27005DA5FC /* URLRequestMaker.swift in Sources */,
 				D0BAD8EF29F6705B0068E24B /* Date+.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Diary/Controller/DetailDiaryViewController.swift
+++ b/Diary/Controller/DetailDiaryViewController.swift
@@ -5,13 +5,17 @@
 //
 
 import UIKit
+import CoreLocation
 
 final class DetailDiaryViewController: UIViewController {
     private var diaryDate: String?
     private var coreDataManager = CoreDataManager.shared
+    private var locationDataManager = LocationDataManager.shared
     private let isDiaryCreated: Bool
     private var isSaveRequired: Bool
     private var diary: Diary?
+    private var latitude: CLLocationDegrees?
+    private var longitude: CLLocationDegrees?
     
     private let diaryTextView: UITextView = {
         let textView = UITextView()
@@ -95,6 +99,12 @@ final class DetailDiaryViewController: UIViewController {
         }
     }
     
+    private func configureLocation() {
+        latitude = locationDataManager.fetchLocation()?.latitude
+        longitude = locationDataManager.fetchLocation()?.longitude
+        print(latitude, longitude)
+    }
+    
     // MARK: - Notification method
     private func addDeactiveNotificationObserver() {
         NotificationCenter.default.addObserver(self,
@@ -153,6 +163,7 @@ final class DetailDiaryViewController: UIViewController {
     
     // MARK: - CoreData method
     private func saveDiary() {
+        configureLocation()
         if isSaveRequired {
             if isDiaryCreated {
                 createDiary()

--- a/Diary/Controller/DetailDiaryViewController.swift
+++ b/Diary/Controller/DetailDiaryViewController.swift
@@ -196,7 +196,11 @@ final class DetailDiaryViewController: UIViewController {
         let title = String(diaryContents[0])
         let body = validBody(diaryContents)
         
-        coreDataManager.createDiary(Diary(id: id, title: title, body: body, date: date, iconName: self.iconName))
+        coreDataManager.createDiary(Diary(id: id,
+                                          title: title,
+                                          body: body,
+                                          date: date,
+                                          iconName: self.iconName))
     }
     
     private func updateDiary() {
@@ -214,7 +218,11 @@ final class DetailDiaryViewController: UIViewController {
         guard let id = diary?.id,
               let date = Date().timeIntervalSince1970.roundDownNumber() else { return }
         
-        coreDataManager.updateDiary(diary: Diary(id: id, title: title, body: body, date: date, iconName: self.iconName))
+        coreDataManager.updateDiary(diary: Diary(id: id,
+                                                 title: title,
+                                                 body: body,
+                                                 date: date,
+                                                 iconName: self.iconName))
     }
     
     private func deleteDiary() {
@@ -247,13 +255,15 @@ final class DetailDiaryViewController: UIViewController {
     // MARK: -
     private func fetchWeatherData(completion: @escaping () -> Void) {
         guard let latitude, let longitude,
-              let request = urlRequestMaker.request(latitude: latitude, longitude: longitude) else { return }
+              let request = urlRequestMaker.request(latitude: latitude,
+                                                    longitude: longitude) else { return }
         
         server.startLoad(request: request) { result in
             do {
                 guard let verifiedFetchingResult = try self.verifyResult(result: result) else { return }
                 
-                let decodedFile = self.decodeManager.decodeJSON(data: verifiedFetchingResult, type: WeatherInformation.self)
+                let decodedFile = self.decodeManager.decodeJSON(data: verifiedFetchingResult,
+                                                                type: WeatherInformation.self)
                 
                 guard let verifiedDecodingResult = try self.verifyResult(result: decodedFile) else { return }
                 

--- a/Diary/Controller/DetailDiaryViewController.swift
+++ b/Diary/Controller/DetailDiaryViewController.swift
@@ -252,7 +252,7 @@ final class DetailDiaryViewController: UIViewController {
         return result
     }
     
-    // MARK: -
+    // MARK: - Network method
     private func fetchWeatherData(completion: @escaping () -> Void) {
         guard let latitude, let longitude,
               let request = urlRequestMaker.request(latitude: latitude,

--- a/Diary/Controller/DetailDiaryViewController.swift
+++ b/Diary/Controller/DetailDiaryViewController.swift
@@ -183,7 +183,6 @@ final class DetailDiaryViewController: UIViewController {
         
         guard let diary = makeDiary() else { return }
         
-        
         fetchWeatherData() {
             if self.isSaveRequired {
                 if self.isDiaryCreated {

--- a/Diary/Controller/DiaryListViewController.swift
+++ b/Diary/Controller/DiaryListViewController.swift
@@ -29,11 +29,6 @@ final class DiaryListViewController: UIViewController {
         addObserver()
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        diaryListTableView.reloadData()
-    }
-    
     private func addObserver() {
         NotificationCenter.default.addObserver(forName: .init("reload"), object: nil, queue: .main) { _ in
             self.diaryListTableView.reloadData()
@@ -87,6 +82,7 @@ extension DiaryListViewController: UITableViewDataSource {
             return DiaryListCell()
         }
         
+        cell.iconImage.image = nil
         cell.accessoryType = .disclosureIndicator
         
         guard let diaries else { return DiaryListCell() }

--- a/Diary/Controller/DiaryListViewController.swift
+++ b/Diary/Controller/DiaryListViewController.swift
@@ -13,7 +13,7 @@ final class DiaryListViewController: UIViewController {
         return coreDataManager.readDiary()
     }
     
-    private let diaryListTableView: UITableView = {
+    let diaryListTableView: UITableView = {
         let tableView = UITableView(frame: .zero, style: .plain)
         tableView.register(DiaryListCell.self, forCellReuseIdentifier: DiaryListCell.identifier)
         tableView.translatesAutoresizingMaskIntoConstraints = false
@@ -26,11 +26,19 @@ final class DiaryListViewController: UIViewController {
         configureUI()
         configureSubview()
         configureConstraint()
+        addObserver()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         diaryListTableView.reloadData()
+    }
+    
+    private func addObserver() {
+        NotificationCenter.default.addObserver(forName: .init("reload"), object: nil, queue: .main) { _ in
+            self.diaryListTableView.reloadData()
+            self.diaryListTableView.layoutIfNeeded()
+        }
     }
     
     private func configureUI() {

--- a/Diary/Controller/DiaryListViewController.swift
+++ b/Diary/Controller/DiaryListViewController.swift
@@ -30,7 +30,9 @@ final class DiaryListViewController: UIViewController {
     }
     
     private func addObserver() {
-        NotificationCenter.default.addObserver(forName: .init("reload"), object: nil, queue: .main) { _ in
+        NotificationCenter.default.addObserver(forName: .init("reload"),
+                                               object: nil,
+                                               queue: .main) { _ in
             self.diaryListTableView.reloadData()
             self.diaryListTableView.layoutIfNeeded()
         }
@@ -118,7 +120,6 @@ extension DiaryListViewController: UITableViewDelegate {
                                                         title: title,
                                                         body: body)
             completionHandler(true)
-            
         }
         
         let delete = UIContextualAction(style: .destructive, title: NameSpace.delete) { action, view, completionHandler in

--- a/Diary/Decode/DecodeError.swift
+++ b/Diary/Decode/DecodeError.swift
@@ -1,8 +1,7 @@
 //
-//  DecodeError.swift
-//  Diary
-//
-//  Created by Jinah Park on 2023/05/11.
+//  Diary - DecodeError.swift
+//  Created by Rhode, 무리.
+//  Copyright © yagom. All rights reserved.
 //
 
 import Foundation

--- a/Diary/Decode/DecodeError.swift
+++ b/Diary/Decode/DecodeError.swift
@@ -1,0 +1,19 @@
+//
+//  DecodeError.swift
+//  Diary
+//
+//  Created by Jinah Park on 2023/05/11.
+//
+
+import Foundation
+
+enum DecodeError: LocalizedError {
+    case decodingFailureError
+    
+    var errorDescription: String? {
+        switch self {
+        case .decodingFailureError:
+            return "해당 file을 디코딩할 수 없습니다."
+        }
+    }
+}

--- a/Diary/Decode/DecodeManager.swift
+++ b/Diary/Decode/DecodeManager.swift
@@ -1,0 +1,22 @@
+//
+//  DecodeManager.swift
+//  Diary
+//
+//  Created by Jinah Park on 2023/05/11.
+//
+
+import UIKit
+
+final class DecodeManager {
+    static let shared = DecodeManager()
+    private let decoder = JSONDecoder()
+    
+    private init() { }
+    
+    func decodeJSON<T: Decodable>(data: Data, type: T.Type) -> Result<T, DecodeError> {
+        
+        guard let decodedJSON: T = try? decoder.decode(type, from: data) else { return .failure(.decodingFailureError) }
+        
+        return .success(decodedJSON)
+    }
+}

--- a/Diary/Decode/DecodeManager.swift
+++ b/Diary/Decode/DecodeManager.swift
@@ -4,7 +4,6 @@
 //  Copyright © yagom. All rights reserved.
 //
 
-
 import UIKit
 
 final class DecodeManager {

--- a/Diary/Decode/DecodeManager.swift
+++ b/Diary/Decode/DecodeManager.swift
@@ -1,9 +1,9 @@
 //
-//  DecodeManager.swift
-//  Diary
+//  Diary - DecodeManager.swift
+//  Created by Rhode, 무리.
+//  Copyright © yagom. All rights reserved.
 //
-//  Created by Jinah Park on 2023/05/11.
-//
+
 
 import UIKit
 

--- a/Diary/Diary.xcdatamodeld/.xccurrentversion
+++ b/Diary/Diary.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Diary.xcdatamodel</string>
+	<string>Diary v2.xcdatamodel</string>
 </dict>
 </plist>

--- a/Diary/Diary.xcdatamodeld/Diary v2.xcdatamodel/contents
+++ b/Diary/Diary.xcdatamodeld/Diary v2.xcdatamodel/contents
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21513" systemVersion="22D68" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Entity" representedClassName="Entity" syncable="YES">
+        <attribute name="body" optional="YES" attributeType="String"/>
+        <attribute name="date" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="iconName" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+    </entity>
+</model>

--- a/Diary/Model/CacheManager.swift
+++ b/Diary/Model/CacheManager.swift
@@ -1,0 +1,30 @@
+//
+//  Diary - CacheManager.swift
+//  Created by Rhode, 무리.
+//  Copyright © yagom. All rights reserved.
+//
+
+import UIKit
+
+final class CacheManager {
+    static let shared = CacheManager()
+    private let storage = NSCache<NSString, UIImage>()
+    
+    private init() {
+        storage.countLimit = 30
+    }
+    
+    func store(image: UIImage, urlString: String) {
+        let key = NSString(string: urlString)
+        self.storage.setObject(image, forKey: key)
+    }
+    
+    func cachedImage(urlString: String) -> UIImage? {
+        let cachedKey = NSString(string: urlString)
+        if let cachedImage = storage.object(forKey: cachedKey) {
+            return cachedImage
+        }
+        
+        return nil
+    }
+}

--- a/Diary/Model/CacheManager.swift
+++ b/Diary/Model/CacheManager.swift
@@ -11,7 +11,7 @@ final class CacheManager {
     private let storage = NSCache<NSString, UIImage>()
     
     private init() {
-        storage.countLimit = 30
+        storage.countLimit = 18
     }
     
     func store(image: UIImage, urlString: String) {

--- a/Diary/Model/CoreDataManager.swift
+++ b/Diary/Model/CoreDataManager.swift
@@ -32,6 +32,7 @@ class CoreDataManager {
     private func saveContext() {
         do {
             try self.context.save()
+            NotificationCenter.default.post(name: .init("reload"), object: nil)
         } catch {
             print(error.localizedDescription)
         }
@@ -44,7 +45,7 @@ class CoreDataManager {
             managedObject.setValue(diary.title, forKey: "title")
             managedObject.setValue(diary.body, forKey: "body")
             managedObject.setValue(diary.date, forKey: "date")
-            
+            managedObject.setValue(diary.iconName, forKey: "iconName")
             saveContext()
         }
     }
@@ -60,8 +61,8 @@ class CoreDataManager {
                   let title = diary.value(forKey: "title") as? String,
                   let body = diary.value(forKey: "body") as? String,
                   let date = diary.value(forKey: "date") as? Double else { return nil }
-            
-            diaries.append(Diary(id: id, title: title, body: body, date: date))
+            let iconName = diary.value(forKey: "iconName") as? String
+            diaries.append(Diary(id: id, title: title, body: body, date: date, iconName: iconName))
         }
         
         return diaries
@@ -82,6 +83,25 @@ class CoreDataManager {
         } catch {
             print(error.localizedDescription)
         }
+        
+        saveContext()
+    }
+    
+    func updateDiary(diary: Diary, iconName: String) {
+        let fetchRequest = NSFetchRequest<NSManagedObject>(entityName: "Entity")
+        fetchRequest.predicate = NSPredicate(format: "id == %@", diary.id as CVarArg)
+        
+        do {
+            let objects = try context.fetch(fetchRequest)
+            let objectToUpdate = objects[0]
+            
+            objectToUpdate.setValue(diary.iconName, forKey: "iconName")
+            
+        } catch {
+            print(error.localizedDescription)
+        }
+        
+        saveContext()
     }
     
     func deleteDiary(diary: Diary) throws {

--- a/Diary/Model/CoreDataManager.swift
+++ b/Diary/Model/CoreDataManager.swift
@@ -79,22 +79,6 @@ class CoreDataManager {
             objectToUpdate.setValue(diary.title, forKey: "title")
             objectToUpdate.setValue(diary.body, forKey: "body")
             objectToUpdate.setValue(diary.date, forKey: "date")
-            
-        } catch {
-            print(error.localizedDescription)
-        }
-        
-        saveContext()
-    }
-    
-    func updateDiary(diary: Diary, iconName: String) {
-        let fetchRequest = NSFetchRequest<NSManagedObject>(entityName: "Entity")
-        fetchRequest.predicate = NSPredicate(format: "id == %@", diary.id as CVarArg)
-        
-        do {
-            let objects = try context.fetch(fetchRequest)
-            let objectToUpdate = objects[0]
-            
             objectToUpdate.setValue(diary.iconName, forKey: "iconName")
             
         } catch {

--- a/Diary/Model/CoreDataManager.swift
+++ b/Diary/Model/CoreDataManager.swift
@@ -7,8 +7,8 @@
 import CoreData
 import Foundation
 
-class CoreDataManager {
-    static var shared: CoreDataManager = CoreDataManager()
+final class CoreDataManager {
+    static var shared = CoreDataManager()
     
     lazy var persistentContainer: NSPersistentContainer = {
         let container = NSPersistentContainer(name: "Diary")

--- a/Diary/Model/DTO/WeatherInformation.swift
+++ b/Diary/Model/DTO/WeatherInformation.swift
@@ -1,0 +1,80 @@
+//
+//  WeatherInformation.swift
+//  Diary
+//
+//  Created by Jinah Park on 2023/05/11.
+//
+
+import Foundation
+
+// MARK: - Welcome
+struct WeatherInformation: Codable {
+    let coord: Coord
+    let weather: [Weather]
+    let base: String
+    let main: Main
+    let visibility: Int
+    let wind: Wind
+    let rain: Rain
+    let clouds: Clouds
+    let dt: Int
+    let sys: Sys
+    let timezone, id: Int
+    let name: String
+    let cod: Int
+}
+
+// MARK: - Clouds
+struct Clouds: Codable {
+    let all: Int
+}
+
+// MARK: - Coord
+struct Coord: Codable {
+    let lon, lat: Double
+}
+
+// MARK: - Main
+struct Main: Codable {
+    let temp, feelsLike, tempMin, tempMax: Double
+    let pressure, humidity, seaLevel, grndLevel: Int
+
+    enum CodingKeys: String, CodingKey {
+        case temp
+        case feelsLike = "feels_like"
+        case tempMin = "temp_min"
+        case tempMax = "temp_max"
+        case pressure, humidity
+        case seaLevel = "sea_level"
+        case grndLevel = "grnd_level"
+    }
+}
+
+// MARK: - Rain
+struct Rain: Codable {
+    let the1H: Double
+
+    enum CodingKeys: String, CodingKey {
+        case the1H = "1h"
+    }
+}
+
+// MARK: - Sys
+struct Sys: Codable {
+    let type, id: Int
+    let country: String
+    let sunrise, sunset: Int
+}
+
+// MARK: - Weather
+struct Weather: Codable {
+    let id: Int
+    let main, description, icon: String
+}
+
+// MARK: - Wind
+struct Wind: Codable {
+    let speed: Double
+    let deg: Int
+    let gust: Double
+}

--- a/Diary/Model/DTO/WeatherInformation.swift
+++ b/Diary/Model/DTO/WeatherInformation.swift
@@ -1,21 +1,18 @@
 //
-//  WeatherInformation.swift
-//  Diary
-//
-//  Created by Jinah Park on 2023/05/11.
+//  Diary - WeatherInformation.swift
+//  Created by Rhode, 무리.
+//  Copyright © yagom. All rights reserved.
 //
 
 import Foundation
 
-// MARK: - Welcome
-struct WeatherInformation: Codable {
+struct WeatherInformation: Decodable {
     let coord: Coord
     let weather: [Weather]
     let base: String
     let main: Main
     let visibility: Int
     let wind: Wind
-    let rain: Rain
     let clouds: Clouds
     let dt: Int
     let sys: Sys
@@ -25,56 +22,44 @@ struct WeatherInformation: Codable {
 }
 
 // MARK: - Clouds
-struct Clouds: Codable {
+struct Clouds: Decodable {
     let all: Int
 }
 
 // MARK: - Coord
-struct Coord: Codable {
+struct Coord: Decodable {
     let lon, lat: Double
 }
 
 // MARK: - Main
-struct Main: Codable {
+struct Main: Decodable {
     let temp, feelsLike, tempMin, tempMax: Double
-    let pressure, humidity, seaLevel, grndLevel: Int
-
+    let pressure, humidity: Int
+    
     enum CodingKeys: String, CodingKey {
         case temp
         case feelsLike = "feels_like"
         case tempMin = "temp_min"
         case tempMax = "temp_max"
         case pressure, humidity
-        case seaLevel = "sea_level"
-        case grndLevel = "grnd_level"
-    }
-}
-
-// MARK: - Rain
-struct Rain: Codable {
-    let the1H: Double
-
-    enum CodingKeys: String, CodingKey {
-        case the1H = "1h"
     }
 }
 
 // MARK: - Sys
-struct Sys: Codable {
+struct Sys: Decodable {
     let type, id: Int
     let country: String
     let sunrise, sunset: Int
 }
 
 // MARK: - Weather
-struct Weather: Codable {
+struct Weather: Decodable {
     let id: Int
     let main, description, icon: String
 }
 
 // MARK: - Wind
-struct Wind: Codable {
+struct Wind: Decodable {
     let speed: Double
     let deg: Int
-    let gust: Double
 }

--- a/Diary/Model/Diary.swift
+++ b/Diary/Model/Diary.swift
@@ -11,4 +11,5 @@ struct Diary {
     var title: String
     var body: String
     var date: Double
+    var iconName: String?
 }

--- a/Diary/Model/LocationDataManager.swift
+++ b/Diary/Model/LocationDataManager.swift
@@ -1,0 +1,74 @@
+//
+//  Diary - LocationDataManager.swift
+//  Created by Rhode, 무리.
+//  Copyright © yagom. All rights reserved.
+//
+
+import CoreLocation
+
+class LocationDataManager: NSObject {
+    static let shared = LocationDataManager()
+    private var locationManager = CLLocationManager()
+    
+    var latitude: CLLocationDegrees?
+    var longitude: CLLocationDegrees?
+    
+    private override init() {
+        super.init()
+        
+        locationManager.delegate = self
+        locationManager.desiredAccuracy = kCLLocationAccuracyHundredMeters
+        locationManager.requestWhenInUseAuthorization()
+    }
+    
+    func startUpdatingLocation() {
+        locationManager.startUpdatingLocation()
+    }
+    
+    func fetchLocation() -> (latitude: CLLocationDegrees, longitude: CLLocationDegrees)? {
+        guard let latitude,
+              let longitude else { return nil }
+        
+        return (latitude: latitude, longitude: longitude)
+    }
+    
+    func requestLocation() {
+        locationManager.requestLocation()
+    }
+    
+    func stopUpdatingLocation() {
+        locationManager.stopUpdatingLocation()
+    }
+}
+
+extension LocationDataManager: CLLocationManagerDelegate {
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        let status = manager.authorizationStatus
+        
+        switch status {
+        case .authorizedAlways, .authorizedWhenInUse:
+            print("GPS 권한 설정됨")
+            manager.startUpdatingLocation()
+        case .restricted, .notDetermined:
+            print("GPS 권한 설정되지 않음")
+            manager.requestWhenInUseAuthorization()
+        case .denied:
+            print("GPS 권한 요청 거부됨")
+            manager.requestWhenInUseAuthorization()
+        default:
+            print("GPS: Default")
+        }
+    }
+    
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let location = locations.last else { return }
+
+        latitude = location.coordinate.latitude
+        longitude = location.coordinate.longitude
+    }
+
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        // Handle location update errors
+        print("Location update failed with error: \(error.localizedDescription)")
+    }
+}

--- a/Diary/Model/LocationDataManager.swift
+++ b/Diary/Model/LocationDataManager.swift
@@ -6,7 +6,7 @@
 
 import CoreLocation
 
-class LocationDataManager: NSObject {
+final class LocationDataManager: NSObject {
     static let shared = LocationDataManager()
     private var locationManager = CLLocationManager()
     
@@ -20,24 +20,12 @@ class LocationDataManager: NSObject {
         locationManager.desiredAccuracy = kCLLocationAccuracyHundredMeters
         locationManager.requestWhenInUseAuthorization()
     }
-    
-    func startUpdatingLocation() {
-        locationManager.startUpdatingLocation()
-    }
-    
+
     func fetchLocation() -> (latitude: CLLocationDegrees, longitude: CLLocationDegrees)? {
         guard let latitude,
               let longitude else { return nil }
         
         return (latitude: latitude, longitude: longitude)
-    }
-    
-    func requestLocation() {
-        locationManager.requestLocation()
-    }
-    
-    func stopUpdatingLocation() {
-        locationManager.stopUpdatingLocation()
     }
 }
 
@@ -68,7 +56,6 @@ extension LocationDataManager: CLLocationManagerDelegate {
     }
 
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
-        // Handle location update errors
         print("Location update failed with error: \(error.localizedDescription)")
     }
 }

--- a/Diary/Network/NetworkError.swift
+++ b/Diary/Network/NetworkError.swift
@@ -1,0 +1,13 @@
+//
+//  Diary - NetworkError.swift
+//  Created by Rhode, 무리.
+//  Copyright © yagom. All rights reserved.
+//
+
+import Foundation
+
+enum NetworkError: Error {
+    case responseError
+    case responseCodeError
+    case dataError
+}

--- a/Diary/Network/NetworkManager.swift
+++ b/Diary/Network/NetworkManager.swift
@@ -9,6 +9,8 @@ final class NetworkManager {
     static let shared = NetworkManager()
     private let urlSession = URLSession(configuration: .default)
     
+    private init() { }
+    
     func startLoad(request: URLRequest, completion: @escaping (Result<Data, NetworkError>) -> Void) {
         urlSession.dataTask(with: request) { data, response, error in
             guard error == nil else {

--- a/Diary/Network/NetworkManager.swift
+++ b/Diary/Network/NetworkManager.swift
@@ -1,0 +1,36 @@
+//
+//  Diary - NetworkManager.swift
+//  Created by Rhode, 무리.
+//  Copyright © yagom. All rights reserved.
+//
+
+import Foundation
+final class NetworkManager {
+    static let shared = NetworkManager()
+    private let urlSession = URLSession(configuration: .default)
+    
+    func startLoad(request: URLRequest, completion: @escaping (Result<Data, NetworkError>) -> Void) {
+        urlSession.dataTask(with: request) { data, response, error in
+            guard error == nil else {
+                completion(.failure(NetworkError.responseError))
+                
+                return
+            }
+            
+            guard let httpResponse = response as? HTTPURLResponse,
+                  (200...299).contains(httpResponse.statusCode) else {
+                completion(.failure(NetworkError.responseCodeError))
+                
+                return
+            }
+            
+            guard let validData = data else {
+                completion(.failure(NetworkError.dataError))
+                
+                return
+            }
+            
+            completion(.success(validData))
+        }.resume()
+    }
+}

--- a/Diary/Network/URLRequestMaker.swift
+++ b/Diary/Network/URLRequestMaker.swift
@@ -1,0 +1,27 @@
+//
+//  Diary - URLRequestMaker.swift
+//  Created by Rhode, 무리.
+//  Copyright © yagom. All rights reserved.
+//
+
+import Foundation
+
+struct URLRequestMaker {
+    private let weatherAPIKey = "2e7f86fff79b58087d75569edba173a1"
+    private let baseURL = "https://api.openweathermap.org/data/2.5/weather"
+ 
+    func request(lattitude: String, longitude: String) -> URLRequest? {
+        var urlComponents = URLComponents(string: baseURL)
+        let lattitude = URLQueryItem(name: "lat", value: lattitude)
+        let longitude = URLQueryItem(name: "lon", value: longitude)
+        let APIkey = URLQueryItem(name: "appid", value: weatherAPIKey)
+        
+        urlComponents?.queryItems = [lattitude, longitude, APIkey]
+        
+        guard let url = urlComponents?.url else { return nil }
+        
+        let request = URLRequest(url: url)
+
+        return request
+    }
+}

--- a/Diary/Network/URLRequestMaker.swift
+++ b/Diary/Network/URLRequestMaker.swift
@@ -10,7 +10,7 @@ struct URLRequestMaker {
     private let weatherAPIKey = "2e7f86fff79b58087d75569edba173a1"
     private let baseURL = "https://api.openweathermap.org/data/2.5/weather"
  
-    func request(lattitude: String, longitude: String) -> URLRequest? {
+    func request(latitude: String, longitude: String) -> URLRequest? {
         var urlComponents = URLComponents(string: baseURL)
         let lattitude = URLQueryItem(name: "lat", value: lattitude)
         let longitude = URLQueryItem(name: "lon", value: longitude)

--- a/Diary/Network/URLRequestMaker.swift
+++ b/Diary/Network/URLRequestMaker.swift
@@ -12,11 +12,11 @@ struct URLRequestMaker {
  
     func request(latitude: String, longitude: String) -> URLRequest? {
         var urlComponents = URLComponents(string: baseURL)
-        let lattitude = URLQueryItem(name: "lat", value: lattitude)
+        let latitude = URLQueryItem(name: "lat", value: latitude)
         let longitude = URLQueryItem(name: "lon", value: longitude)
         let APIkey = URLQueryItem(name: "appid", value: weatherAPIKey)
         
-        urlComponents?.queryItems = [lattitude, longitude, APIkey]
+        urlComponents?.queryItems = [latitude, longitude, APIkey]
         
         guard let url = urlComponents?.url else { return nil }
         

--- a/Diary/Resource/Info.plist
+++ b/Diary/Resource/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>사용자의 지역에 따른 날씨 정보를 제공하기 위하여 권한이 필요합니다.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>사용자의 지역에 따른 날씨 정보를 제공하기 위하여 권한이 필요합니다.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Diary/View/DiaryListCell.swift
+++ b/Diary/View/DiaryListCell.swift
@@ -49,7 +49,7 @@ final class DiaryListCell: UITableViewCell {
         return label
     }()
     
-    private let iconImage: UIImageView = {
+    let iconImage: UIImageView = {
         let imageView = UIImageView()
         imageView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         

--- a/Diary/View/DiaryListCell.swift
+++ b/Diary/View/DiaryListCell.swift
@@ -36,6 +36,7 @@ final class DiaryListCell: UITableViewCell {
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: .body)
         label.setContentCompressionResistancePriority(.required, for: .horizontal)
+        label.setContentHuggingPriority(.required, for: .horizontal)
         
         return label
     }()
@@ -43,8 +44,16 @@ final class DiaryListCell: UITableViewCell {
     private let bodyLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: .caption1)
+        label.textAlignment = .right
         
         return label
+    }()
+    
+    private let iconImage: UIImageView = {
+        let imageView = UIImageView()
+        imageView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        
+        return imageView
     }()
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -61,6 +70,26 @@ final class DiaryListCell: UITableViewCell {
         titleLabel.text = data.title
         bodyLabel.text = data.body.removeNewLinePrefix()
         dateLabel.text = Date(timeIntervalSince1970: data.date).convertDate()
+        
+        guard let url = URL(string: imageURLString(diary: data)) else { return }
+        DispatchQueue.global().async { [weak self] in
+            if let data = try? Data(contentsOf: url) {
+                if let image = UIImage(data: data) {
+                    DispatchQueue.main.async {
+                        self?.iconImage.image = image
+                    }
+                }
+            }
+        }
+    }
+    
+    private func imageURLString(diary: Diary) -> String {
+        guard let iconName = diary.iconName else { return "" }
+        
+        let baseURL = "https://openweathermap.org/img/wn/"
+        let resolution = "@2x.png"
+        
+        return baseURL + iconName + resolution
     }
     
     private func configureSubViews() {
@@ -68,6 +97,7 @@ final class DiaryListCell: UITableViewCell {
         contentStackView.addArrangedSubview(titleLabel)
         contentStackView.addArrangedSubview(detailStackView)
         detailStackView.addArrangedSubview(dateLabel)
+        detailStackView.addArrangedSubview(iconImage)
         detailStackView.addArrangedSubview(bodyLabel)
     }
     
@@ -76,7 +106,9 @@ final class DiaryListCell: UITableViewCell {
             contentStackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 10),
             contentStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -10),
             contentStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 10),
-            contentStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -10)
+            contentStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -10),
+            iconImage.widthAnchor.constraint(equalTo: contentStackView.widthAnchor, multiplier: 1/10),
+            iconImage.heightAnchor.constraint(equalTo: iconImage.widthAnchor)
         ])
     }
 }

--- a/Entity+CoreDataProperties.swift
+++ b/Entity+CoreDataProperties.swift
@@ -1,7 +1,9 @@
 //
-//  Diary - Entity+CoreDataProperties.swift
-//  Created by Rhode, 무리.
-//  Copyright © yagom. All rights reserved.
+//  Entity+CoreDataProperties.swift
+//  Diary
+//
+//  Created by 박소연 on 2023/05/11.
+//
 //
 
 import Foundation
@@ -13,9 +15,11 @@ extension Entity {
         return NSFetchRequest<Entity>(entityName: "Entity")
     }
 
-    @NSManaged public var title: String?
     @NSManaged public var body: String?
     @NSManaged public var date: Double
+    @NSManaged public var id: UUID?
+    @NSManaged public var title: String?
+    @NSManaged public var iconName: String?
 
 }
 

--- a/Entity+CoreDataProperties.swift
+++ b/Entity+CoreDataProperties.swift
@@ -1,9 +1,7 @@
 //
-//  Entity+CoreDataProperties.swift
-//  Diary
-//
-//  Created by 박소연 on 2023/05/11.
-//
+//  Diary - Entity+CoreDataProperties.swift
+//  Created by Rhode, 무리.
+//  Copyright © yagom. All rights reserved.
 //
 
 import Foundation

--- a/README.md
+++ b/README.md
@@ -618,16 +618,15 @@ extension Entity {
     
 </br>
 ## Reference 📑
-[🍎 Apple Developer 공식문서 - UITextView ](https://developer.apple.com/documentation/uikit/uitextview)
-[🍎 Apple Developer 공식문서 - DateFormatter ](https://developer.apple.com/documentation/foundation/dateformatter)
-[🍎 Apple Developer 공식문서 - NotificationCenter ](https://developer.apple.com/documentation/foundation/notificationcenter)
-[🍎 Apple Developer 공식문서 - NSNotification-Name-UIKit ](https://developer.apple.com/documentation/foundation/nsnotification/name#3875993)
-[🍎 Apple Developer 공식문서 - NsLayoutConstraint-constant ](https://developer.apple.com/documentation/uikit/nslayoutconstraint/1526928-constant)
-[🍎 Apple Developer 공식문서 - Core Data](https://developer.apple.com/documentation/coredata)
-[🍎 Apple Developer 공식문서 - Core Location](https://developer.apple.com/documentation/corelocation)
-[🍎 Apple Developer 공식문서 - Configuring your app to use location services](https://developer.apple.com/documentation/corelocation/configuring_your_app_to_use_location_services)
-[🍎 Apple Developer 공식문서 - Getting the current location of a device](https://developer.apple.com/documentation/corelocation/getting_the_current_location_of_a_device)
-[🍎 Apple Developer 공식문서 - Requesting authorization to use location services](https://developer.apple.com/documentation/corelocation/requesting_authorization_to_use_location_services)
-[🍎 Apple Developer 공식문서 - Using Lightweight Migration](https://developer.apple.com/documentation/coredata/using_lightweight_migration)
-[🌤️ OpenWeatherAPI](https://openweathermap.org/current#multi)
-
+- [🍎 Apple Developer 공식문서 - UITextView ](https://developer.apple.com/documentation/uikit/uitextview)
+- [🍎 Apple Developer 공식문서 - DateFormatter ](https://developer.apple.com/documentation/foundation/dateformatter)
+- [🍎 Apple Developer 공식문서 - NotificationCenter ](https://developer.apple.com/documentation/foundation/notificationcenter)
+- [🍎 Apple Developer 공식문서 - NSNotification-Name-UIKit ](https://developer.apple.com/documentation/foundation/nsnotification/name#3875993)
+- [🍎 Apple Developer 공식문서 - NsLayoutConstraint-constant ](https://developer.apple.com/documentation/uikit/nslayoutconstraint/1526928-constant)
+- [🍎 Apple Developer 공식문서 - Core Data](https://developer.apple.com/documentation/coredata)
+- [🍎 Apple Developer 공식문서 - Core Location](https://developer.apple.com/documentation/corelocation)
+- [🍎 Apple Developer 공식문서 - Configuring your app to use location services](https://developer.apple.com/documentation/corelocation/configuring_your_app_to_use_location_services)
+- [🍎 Apple Developer 공식문서 - Getting the current location of a device](https://developer.apple.com/documentation/corelocation/getting_the_current_location_of_a_device)
+- [🍎 Apple Developer 공식문서 - Requesting authorization to use location services](https://developer.apple.com/documentation/corelocation/requesting_authorization_to_use_location_services)
+- [🍎 Apple Developer 공식문서 - Using Lightweight Migration](https://developer.apple.com/documentation/coredata/using_lightweight_migration)
+- [🌤️ OpenWeatherAPI](https://openweathermap.org/current#multi)

--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@
 
 
 - [1. 팀원을 소개합니다 👀](#팀원을-소개합니다-) 
-- [2. 파일트리 🌲](#file-tree-)
+- [2. 프로젝트 구조 🔍](#프로젝트-구조-)
 - [3. 타임라인 ⏰](#타임라인-) 
 - [4. 실행 화면 🎬](#실행-화면-) 
 - [5. 트러블슈팅 🚀](#트러블-슈팅-) 
 - [6. 핵심경험 📌](#핵심경험-)
-- [7. Reference 📑](#reference-) 
+- [7. 팀 회고 👯‍♀️](#팀-회고-)
+- [8. Reference 📑](#reference-) 
 
 </br>
 
@@ -27,7 +28,9 @@
 
 </br>
 
-## File Tree 🌲
+## 프로젝트 구조 🔍
+
+### File Tree 🌲
 
 ```typescript
 Diary
@@ -38,14 +41,25 @@ Diary
 │   │   ├── AppDelegate.swift
 │   │   └── SceneDelegate.swift
 │   ├── Model
+│   │   ├── DTO
+│   │   │   └── WeatherInformation.swift
 │   │   ├── Diary.swift
-│   │   └── CoreDataManager.swift
+│   │   ├── CoreDataManager.swift
+│   │   ├── LocationDataManager.swift
+│   │   └── CacheManager.swift
 │   ├── View
 │   │   ├── LaunchScreen
 │   │   └── DiaryListCell.swift
 │   ├── Controller
 │   │   ├── DiaryListViewController.swift
 │   │   └── DetailDiaryViewController.swift
+│   ├── Decode
+│   │   ├── DecodeManager.swift
+│   │   └── DecodeError.swift
+│   ├── Network
+│   │   ├── URLRequestMaker.swift
+│   │   ├── NetworkManager.swift
+│   │   └── NetworkError.swift
 │   ├── Utility
 │   │   └── ActionController.swift
 │   ├── Resource
@@ -56,8 +70,14 @@ Diary
 │       ├── Double+.swift
 │       └── String+.swift
 ├── Diary
+│       ├── Diary v2
+│       └── Diary
 └── .swiftlint
 ```
+
+### UML 📊
+
+![](https://hackmd.io/_uploads/ByL0CDo42.png)
 
 
 </br>
@@ -75,7 +95,11 @@ Diary
 | **2023.05.02** | - CoreData deleteDiary()구현 </br>- 테이블에서 스와이프 및 삭제 구현 </br>- Entity에 id 프로퍼티 추가 </br>- DetailDiaryViewController updateDiary()구현 </br>- showActivieyVC() 구현 및 NotificationObserver 추가 |
 | **2023.05.03** | - 일기 저장 로직 수정 </br>- CoreData delete로직 수정 및 DetailDiaryViewController에서 삭제기능 추가 </br>- 스와이프 로직 수정 </br>- ActionViewController 분리 </br>- DetailViewController에서 삭제 시 alert 구현 </br>- 키보드 레이아웃 로직 keyboardLayout으로 수정|
 | **2023.05.04** | - ActivityViewController에서 다이어리 내용 전달할 수 있게 수정 </br>- 바번튼 아이템 수정 </br>- DetailDiaryViewController updateDiary() 로직 수정 </br>- 다이어리 저장 시 중복으로 저장되는 오류 처리|
-
+| **2023.05.05** | - DiaryListViewController가 Diary 변수를 가지도록 수정</br>- 수정 중 저장기능 리팩토링|
+| **2023.05.08** | - 에러처리 방법 변경 </br>- CoreDataManager 내부 반복 로직 메서드로 분리|
+| **2023.05.09** | - Core Location 구현 및 Location Manager 생성 </br>- NetworkManger 구현 </br>- DecodeManager 구현</br>- CoreData Migration 및 로직 오류 해결|
+| **2023.05.11** | - ActivityViewController에서 다이어리 내용 전달할 수 있게 수정 </br>- 바번튼 아이템 수정 </br>- DetailDiaryViewController updateDiary() 로직 수정 </br>- 다이어리 저장 시 중복으로 저장되는 오류 처리|
+| **2023.05.12** | - URL 사용하여 ListCell에 날씨 아이콘 추가 및 오류 수정 </br>- Cache Manager 구현 및 아이콘 이미지 캐싱|
 
 </br>
 
@@ -109,6 +133,19 @@ Diary
 |<center>생성 화면</center>|<center>수정 화면</center>|
 | --- | --- |
 |<img src=https://i.imgur.com/1kl70hn.gif width=300>|<img src=https://i.imgur.com/FKQ1aVk.gif width=300>|
+
+
+
+## 날씨 아이콘 추가 후 CRUD
+|<center>Create</center>|<center>Read&Update</center>|<center>Delete</center>
+|---|---|---|
+|<img src=https://hackmd.io/_uploads/B17zePs43.gif width=300>|<img src=https://hackmd.io/_uploads/rkmGewjVn.gif width=300>|<img src=https://hackmd.io/_uploads/S1QflviV2.gif width=300>
+
+## 날씨 아이콘 이미지 캐싱
+
+|<center>이미지 캐싱 전</center>|<center>이미지 캐싱 후</center>|
+|---|---|
+|<img src=https://hackmd.io/_uploads/r1HtWwiNn.gif width=300>|<img src=https://hackmd.io/_uploads/HkvIe_sEh.gif width=300>|
 
 ---
 
@@ -185,7 +222,6 @@ private func keyboardWillHide(notification: NSNotification) {
 
 ### 2️⃣ 사용자가 키보드를 내릴 때 텍스트뷰의 레이아웃
 현재 트러블슈팅 1️⃣에서는 **키보드가 올라왔을 때** 텍스트 뷰의 크기를 동적으로 줄여 사용하고있었습니다. `⌘+k`를 이용하여 키보드를 없앨 때는 느끼지 못했던 부분인 **사용자가 키보드를 내릴 때**의 텍스트 뷰 레이아웃이 어색하게 느껴졌습니다.
-
 <img src=https://i.imgur.com/PfWmHP8.gif width=300>
 
 이를 해결하기 위해 **iOS 15.0+** 부터 사용 가능한  `keyboardLayoutGuide`를 사용해주었습니다.
@@ -240,10 +276,7 @@ barButtonItem의 image를 UIImage에 넣어 사용하는 방법으로 한결 간
 
 그래서 각각의 상황에 `saveDiary()`메서드를 넣어주었습니다:
 ```swift
-
-
 @objc
-
 final class DetailDiaryViewController: UIViewController {
     
     ...
@@ -287,6 +320,31 @@ private func saveDiary() {
 ```
 `isSaveRequired`는 `DiaryListViewController`에서 `addDiary()`를 해줄 때 혹은 테이블뷰의 셀을 선택할 때, true로 초기화됩니다. 그래서 이 때는 `if isSaveRequired`를 타고 들어가 `createDiary()`혹은 `updateDiary()`가 호출됩니다. 그렇지만, 나머지 상황에서는 `isSaveRequired`가 false이기 때문에 일기가 저장되거나 수정되지 않습니다. 
 
+### 5️⃣ DiaryListVC의 `.reloadData()`의 호출 순서 오류
+로직 수정 중, DiaryListViewController의 `viewWillAppear()` 내부에서 사용하고있는 `diaryTableView.reloadData()`가 제대로 작동하지 않은 오류가 있었습니다. 
+확인 결과 사용하고있던 escaping closure가 뷰컨트롤러의 전환 후 작동하여 나타났던 오류로, 일기장 작성 페이지에서 뒤로가기 시 저장이 되는 로직을 가지고 있었기 때문에 화면전환 시 불리우는 CoreDataManager의 `saveContext()` 메서드에 Notification의 post기능을 이용하여 해결할 수 있었습니다.
+```swift!
+// CoreDataManager.swift
+private func saveContext() {
+    do {
+        try self.context.save()
+        NotificationCenter.default.post(name: .init("reload"), object: nil)
+    } catch {
+        print(error.localizedDescription)
+    }
+}
+```
+```swift
+// DiaryListViewController.swift
+private func addObserver() {
+    NotificationCenter.default.addObserver(forName: .init("reload"),
+                                           object: nil,
+                                           queue: .main) { _ in
+        self.diaryListTableView.reloadData()
+        self.diaryListTableView.layoutIfNeeded()
+    }
+}
+```
 
 
 <br/>
@@ -465,15 +523,111 @@ enum ActionController {
     }
 }
 ```
+
+</details>
+    
+<details>
+<summary><big>✅ Core Location 활용 </big></summary>
+    
+일기를 저장하는 장소에서의 현재 날씨를 구하기 위해, Core Location을 활용하여 해당 지역의 위/경도를 구할 수 있었습니다. 
+    
+```swift 
+// LocationDataManager.swift
+final class LocationDataManager: NSObject {
+    static let shared = LocationDataManager()
+    private var locationManager = CLLocationManager()
+
+    var latitude: CLLocationDegrees?
+    var longitude: CLLocationDegrees?
+
+    private override init() {
+        super.init()
+
+        locationManager.delegate = self
+        locationManager.desiredAccuracy = kCLLocationAccuracyHundredMeters
+        locationManager.requestWhenInUseAuthorization()
+    }
+
+    func fetchLocation() -> (latitude: CLLocationDegrees, longitude: CLLocationDegrees)? {
+        guard let latitude,
+              let longitude else { return nil }
+
+        return (latitude: latitude, longitude: longitude)
+    }
+}
+    
+extension LocationDataManager: CLLocationManagerDelegate {
+    // 권한설정 메서드 등
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let location = locations.last else { return }
+
+        latitude = location.coordinate.latitude
+        longitude = location.coordinate.longitude
+    }
+}
+```
     
 </details>
     
-</br>
+<details>
+<summary><big>✅ Core Data Lightweight Migration</big></summary>
+OpenWeather API에서 받아오는 날씨의 icon값을 저장하기 위해 Core Data의 Migration을 할 필요가 있었습니다. 
+CoreData에서 `Add Model Version`을 하여 새로운 버전을 관리 해 주었습니다. 그 후 `Create NSManagedObject Subclass`하여 수정 내용을 반영해준 후 실행하여 마이그레이션을 해볼 수 있었습니다.
+    
+```swift
+import Foundation
+import CoreData
 
+extension Entity {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Entity> {
+        return NSFetchRequest<Entity>(entityName: "Entity")
+    }
+
+    @NSManaged public var body: String?
+    @NSManaged public var date: Double
+    @NSManaged public var id: UUID?
+    @NSManaged public var title: String?
+    @NSManaged public var iconName: String?
+}
+// ...
+    
+```
+    
+</details>
+        
+    
+</br>
+    
+## 팀 회고 👯‍♀️
+    
+### 우리팀이 잘한 점
+- 리뷰가 오기 전에 각자 집중해서 공부할 수 있는 시간을 가졌던 점이 참 좋았습니다.
+- 그라운드 룰에 적어놓은 시간약속을 잘 지켰어요!
+    
+### 우리 팀의 아쉬웠던 점
+- 프로젝트 후반부에 체력적으로 많이 지쳤던 것 같아요...😭
+- 자잘한 실수 큰 오류...😅
+
+### 팀원 서로 칭찬하기
+#### 무리 -> 로데
+로데의 넓은 지식...! 멋져요. 로데 덕분에 새로운 메서드, 컨벤션 등 많이 알아갑니다! 오류를 만났을때도 이런저런 방법으로 시도해보시는 점 너무 멋있었습니다! 공식문서와 가까우신 점, 코드짜실 때 일관성있는 점도 꼭 배우고싶은 부분입니다. 로데는 정말 어디가서든지 적응 잘하실것같아요🥹 로데 최고입니다!!!
+
+#### 로데 -> 무리
+무리는 유연한 사고와 꼼꼼함을 두루 갖추고 있는 정육각형 개발자입니다. 늘 성실하면서도 생각이나 일정을 계획하는데에 있어서 유연함을 가지고 있어서 배울 점이 많습니다. 체력 안배도 잘 하시는 편인지 후반부에 체력적으로 많이 지쳤음에도 프로젝트를 이끌어나갈 힘이 있으신 것 같았습니다. 모든 점을 균형있게 잘 하시는 것이 무리의 가장 큰 장점이라고 볼 수 있을 것 같습니다.
+
+    
+</br>
 ## Reference 📑
-- [🍎 Apple Developer 공식문서 - UITextView](https://developer.apple.com/documentation/uikit/uitextview)
-- [🍎 Apple Developer 공식문서 - DateFormatter](https://developer.apple.com/documentation/foundation/dateformatter)
-- [🍎 Apple Developer 공식문서 - NotificationCenter](https://developer.apple.com/documentation/foundation/notificationcenter)
-- [🍎 Apple Developer 공식문서 - NSNotification-Name-UIKit](https://developer.apple.com/documentation/foundation/nsnotification/name#3875993)
-- [🍎 Apple Developer 공식문서 - NsLayoutConstraint-constant](https://developer.apple.com/documentation/uikit/nslayoutconstraint/1526928-constant)
-- [🍎 Apple Developer 공식문서 - CoreData](https://developer.apple.com/documentation/coredata)
+[🍎 Apple Developer 공식문서 - UITextView ](https://developer.apple.com/documentation/uikit/uitextview)
+[🍎 Apple Developer 공식문서 - DateFormatter ](https://developer.apple.com/documentation/foundation/dateformatter)
+[🍎 Apple Developer 공식문서 - NotificationCenter ](https://developer.apple.com/documentation/foundation/notificationcenter)
+[🍎 Apple Developer 공식문서 - NSNotification-Name-UIKit ](https://developer.apple.com/documentation/foundation/nsnotification/name#3875993)
+[🍎 Apple Developer 공식문서 - NsLayoutConstraint-constant ](https://developer.apple.com/documentation/uikit/nslayoutconstraint/1526928-constant)
+[🍎 Apple Developer 공식문서 - Core Data](https://developer.apple.com/documentation/coredata)
+[🍎 Apple Developer 공식문서 - Core Location](https://developer.apple.com/documentation/corelocation)
+[🍎 Apple Developer 공식문서 - Configuring your app to use location services](https://developer.apple.com/documentation/corelocation/configuring_your_app_to_use_location_services)
+[🍎 Apple Developer 공식문서 - Getting the current location of a device](https://developer.apple.com/documentation/corelocation/getting_the_current_location_of_a_device)
+[🍎 Apple Developer 공식문서 - Requesting authorization to use location services](https://developer.apple.com/documentation/corelocation/requesting_authorization_to_use_location_services)
+[🍎 Apple Developer 공식문서 - Using Lightweight Migration](https://developer.apple.com/documentation/coredata/using_lightweight_migration)
+[🌤️ OpenWeatherAPI](https://openweathermap.org/current#multi)
+

--- a/README.md
+++ b/README.md
@@ -618,6 +618,7 @@ extension Entity {
     
 </br>
 ## Reference 📑
+    
 - [🍎 Apple Developer 공식문서 - UITextView ](https://developer.apple.com/documentation/uikit/uitextview)
 - [🍎 Apple Developer 공식문서 - DateFormatter ](https://developer.apple.com/documentation/foundation/dateformatter)
 - [🍎 Apple Developer 공식문서 - NotificationCenter ](https://developer.apple.com/documentation/foundation/notificationcenter)


### PR DESCRIPTION
@forestjae
숲재...! 다급한 STEP 3 PR입니다...
시간이 촉박하기도 하고 필요한 메서드를 호출하지 않거나, API예시 모델이 응답 모델과 달랐던 점 등의 이슈로 인하여 오류가 계속 발생하는 사사로운 문제에 삽질을 많이 해서 다소 마무리가 덜 되었습니다..
그래도 숲재께 리뷰를 받고 싶어 부족한 코드이지만 PR을 보내봅니다.
부디 노여워마시고..
리뷰 잘부탁드리겠습니다😭....

## 고민했던 점
### 1️⃣ 수정 시에 반영해야 하는 정보의 범위
STEP 2까지의 진행상황에서 저희 프로젝트에서는 일기의 제목과 내용, 날짜를 수정해주고 있었습니다. Diary 모델에 `iconName`이 생긴 후 어디까지 수정을 해야하는 지에 대해 생각해보았습니다. 
상의 후 **새로 저장하는 시점에서의 날씨를 저장해주어야 한다**라는 의견에 동의하여 `iconName`까지 수정해주는 방향으로 진행하였습니다. 

### 2️⃣ DiaryListVC의 `.reloadData()`의 호출 순서 오류
로직 수정 중, DiaryListViewController의 `viewWillAppear()` 내부에서 사용하고있는 `diaryTableView.reloadData()`가 제대로 작동하지 않은 오류가 있었습니다. 
확인 결과 사용하고있던 escaping closure가 뷰컨트롤러의 전환 후 작동하여 나타났던 오류로, 일기장 작성 페이지에서 뒤로가기 시 저장이 되는 로직을 가지고 있었기 때문에 화면전환 시 불리우는 CoreDataManager의 `saveContext()` 메서드에 Notification의 post기능을 이용하여 해결하였습니다.
