### PR TITLE
일기장 [STEP 2] Max, Hemg

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,3 +5,5 @@ excluded:
 - Pods
 - Diary/App/AppDelegate.swift
 - Diary/App/SceneDelegate.swift
+- Diary/Model/Diary+CoreDataClass.swift
+- Diary/Model/Diary+CoreDataProperties.swift

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,5 @@
 disabled_rules:
 - trailing_whitespace
-- line_length
 
 excluded:
 - Pods

--- a/Diary+CoreDataClass.swift
+++ b/Diary+CoreDataClass.swift
@@ -6,10 +6,7 @@
 //
 //
 
-import Foundation
 import CoreData
 
 @objc(Diary)
-public class Diary: NSManagedObject {
-
-}
+public class Diary: NSManagedObject {}

--- a/Diary+CoreDataClass.swift
+++ b/Diary+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  Diary+CoreDataClass.swift
+//  Diary
+//
+//  Created by 1 on 2023/09/01.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(Diary)
+public class Diary: NSManagedObject {
+
+}

--- a/Diary+CoreDataClass.swift
+++ b/Diary+CoreDataClass.swift
@@ -2,7 +2,7 @@
 //  Diary+CoreDataClass.swift
 //  Diary
 //
-//  Created by 1 on 2023/09/01.
+//  Created by Max, Hemg on 2023/09/01.
 //
 //
 

--- a/Diary+CoreDataProperties.swift
+++ b/Diary+CoreDataProperties.swift
@@ -2,13 +2,12 @@
 //  Diary+CoreDataProperties.swift
 //  Diary
 //
-//  Created by 1 on 2023/09/01.
+//  Created by Max, Hemg on 2023/09/01.
 //
 //
 
 import Foundation
 import CoreData
-
 
 extension Diary {
 
@@ -23,6 +22,4 @@ extension Diary {
 
 }
 
-extension Diary : Identifiable {
-
-}
+extension Diary: Identifiable {}

--- a/Diary+CoreDataProperties.swift
+++ b/Diary+CoreDataProperties.swift
@@ -1,0 +1,28 @@
+//
+//  Diary+CoreDataProperties.swift
+//  Diary
+//
+//  Created by 1 on 2023/09/01.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension Diary {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Diary> {
+        return NSFetchRequest<Diary>(entityName: "Diary")
+    }
+
+    @NSManaged public var title: String?
+    @NSManaged public var body: String?
+    @NSManaged public var createdAt: Date?
+    @NSManaged public var id: UUID?
+
+}
+
+extension Diary : Identifiable {
+
+}

--- a/Diary+CoreDataProperties.swift
+++ b/Diary+CoreDataProperties.swift
@@ -16,7 +16,8 @@ extension Diary {
     @NSManaged public var title: String?
     @NSManaged public var body: String?
     @NSManaged public var createdAt: Date?
-    @NSManaged public var id: UUID?
 }
 
-extension Diary: Identifiable {}
+extension Diary: Identifiable {
+    @NSManaged public var id: UUID?
+}

--- a/Diary+CoreDataProperties.swift
+++ b/Diary+CoreDataProperties.swift
@@ -6,11 +6,9 @@
 //
 //
 
-import Foundation
 import CoreData
 
 extension Diary {
-
     @nonobjc public class func fetchRequest() -> NSFetchRequest<Diary> {
         return NSFetchRequest<Diary>(entityName: "Diary")
     }
@@ -19,7 +17,6 @@ extension Diary {
     @NSManaged public var body: String?
     @NSManaged public var createdAt: Date?
     @NSManaged public var id: UUID?
-
 }
 
 extension Diary: Identifiable {}

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		BA1A55EB2A9D84AF0012C89D /* DiaryEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1A55EA2A9D84AF0012C89D /* DiaryEntity.swift */; };
 		BA1A55ED2A9D90810012C89D /* DateFormatter+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1A55EC2A9D90810012C89D /* DateFormatter+.swift */; };
 		BABBDAE52A9F13A200D8D50B /* DecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABBDAE42A9F13A200D8D50B /* DecodingError.swift */; };
+		BABBDB342AA6D05A00D8D50B /* ShareDiary.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABBDB332AA6D05A00D8D50B /* ShareDiary.swift */; };
 		C739AE25284DF28600741E8F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C739AE24284DF28600741E8F /* AppDelegate.swift */; };
 		C739AE27284DF28600741E8F /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C739AE26284DF28600741E8F /* SceneDelegate.swift */; };
 		C739AE29284DF28600741E8F /* DiaryListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C739AE28284DF28600741E8F /* DiaryListViewController.swift */; };
@@ -40,6 +41,7 @@
 		BA1A55EA2A9D84AF0012C89D /* DiaryEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryEntity.swift; sourceTree = "<group>"; };
 		BA1A55EC2A9D90810012C89D /* DateFormatter+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+.swift"; sourceTree = "<group>"; };
 		BABBDAE42A9F13A200D8D50B /* DecodingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodingError.swift; sourceTree = "<group>"; };
+		BABBDB332AA6D05A00D8D50B /* ShareDiary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareDiary.swift; sourceTree = "<group>"; };
 		C739AE21284DF28600741E8F /* Diary.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Diary.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C739AE24284DF28600741E8F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C739AE26284DF28600741E8F /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -85,6 +87,7 @@
 			isa = PBXGroup;
 			children = (
 				636B19AB2AA6C5E900B5242D /* AlertDisplayble.swift */,
+				BABBDB332AA6D05A00D8D50B /* ShareDiary.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -315,6 +318,7 @@
 				63BB62B52AA182AA00524DCB /* CoreDataManager.swift in Sources */,
 				63E527392A9D97160000FBA6 /* CreateDiaryViewController.swift in Sources */,
 				BABBDAE52A9F13A200D8D50B /* DecodingError.swift in Sources */,
+				BABBDB342AA6D05A00D8D50B /* ShareDiary.swift in Sources */,
 				63BB62B32AA181BE00524DCB /* Diary+CoreDataProperties.swift in Sources */,
 				BA1A55EB2A9D84AF0012C89D /* DiaryEntity.swift in Sources */,
 				63BB62B22AA181BE00524DCB /* Diary+CoreDataClass.swift in Sources */,

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -9,13 +9,15 @@
 /* Begin PBXBuildFile section */
 		459D493A878338290A3E0AEF /* Pods_Diary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDF8EB908CAD9D062C72898B /* Pods_Diary.framework */; };
 		636B19AC2AA6C5E900B5242D /* AlertDisplayble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636B19AB2AA6C5E900B5242D /* AlertDisplayble.swift */; };
+		63B12BAE2AAD9C9000D614A6 /* AlertNamespace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B12BAD2AAD9C9000D614A6 /* AlertNamespace.swift */; };
+		63B12BB02AAD9D3400D614A6 /* ButtonNamespace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B12BAF2AAD9D3400D614A6 /* ButtonNamespace.swift */; };
 		63BB62822A9F109400524DCB /* DecodingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BB62812A9F109400524DCB /* DecodingManager.swift */; };
 		63BB62B22AA181BE00524DCB /* Diary+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BB62B02AA181BE00524DCB /* Diary+CoreDataClass.swift */; };
 		63BB62B32AA181BE00524DCB /* Diary+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BB62B12AA181BE00524DCB /* Diary+CoreDataProperties.swift */; };
 		63BB62B52AA182AA00524DCB /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BB62B42AA182AA00524DCB /* CoreDataManager.swift */; };
 		63E527352A9D7EBF0000FBA6 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 63E527342A9D7EBF0000FBA6 /* .swiftlint.yml */; };
 		63E527372A9D87660000FBA6 /* DiaryListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E527362A9D87660000FBA6 /* DiaryListTableViewCell.swift */; };
-		63E527392A9D97160000FBA6 /* CreateDiaryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E527382A9D97160000FBA6 /* CreateDiaryViewController.swift */; };
+		63E527392A9D97160000FBA6 /* DiaryDetailViewContoller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E527382A9D97160000FBA6 /* DiaryDetailViewContoller.swift */; };
 		BA1A55EB2A9D84AF0012C89D /* DiaryEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1A55EA2A9D84AF0012C89D /* DiaryEntity.swift */; };
 		BA1A55ED2A9D90810012C89D /* DateFormatter+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1A55EC2A9D90810012C89D /* DateFormatter+.swift */; };
 		BABBDAE52A9F13A200D8D50B /* DecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABBDAE42A9F13A200D8D50B /* DecodingError.swift */; };
@@ -31,13 +33,15 @@
 
 /* Begin PBXFileReference section */
 		636B19AB2AA6C5E900B5242D /* AlertDisplayble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertDisplayble.swift; sourceTree = "<group>"; };
+		63B12BAD2AAD9C9000D614A6 /* AlertNamespace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertNamespace.swift; sourceTree = "<group>"; };
+		63B12BAF2AAD9D3400D614A6 /* ButtonNamespace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonNamespace.swift; sourceTree = "<group>"; };
 		63BB62812A9F109400524DCB /* DecodingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodingManager.swift; sourceTree = "<group>"; };
 		63BB62B02AA181BE00524DCB /* Diary+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Diary+CoreDataClass.swift"; sourceTree = SOURCE_ROOT; };
 		63BB62B12AA181BE00524DCB /* Diary+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Diary+CoreDataProperties.swift"; sourceTree = SOURCE_ROOT; };
 		63BB62B42AA182AA00524DCB /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
 		63E527342A9D7EBF0000FBA6 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		63E527362A9D87660000FBA6 /* DiaryListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListTableViewCell.swift; sourceTree = "<group>"; };
-		63E527382A9D97160000FBA6 /* CreateDiaryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateDiaryViewController.swift; sourceTree = "<group>"; };
+		63E527382A9D97160000FBA6 /* DiaryDetailViewContoller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryDetailViewContoller.swift; sourceTree = "<group>"; };
 		7B86D20E06F2B506DECF94F6 /* Pods-Diary.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Diary.release.xcconfig"; path = "Target Support Files/Pods-Diary/Pods-Diary.release.xcconfig"; sourceTree = "<group>"; };
 		BA1A55EA2A9D84AF0012C89D /* DiaryEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryEntity.swift; sourceTree = "<group>"; };
 		BA1A55EC2A9D90810012C89D /* DateFormatter+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+.swift"; sourceTree = "<group>"; };
@@ -118,6 +122,8 @@
 				63BB62B12AA181BE00524DCB /* Diary+CoreDataProperties.swift */,
 				BA1A55EA2A9D84AF0012C89D /* DiaryEntity.swift */,
 				63BB62812A9F109400524DCB /* DecodingManager.swift */,
+				63B12BAD2AAD9C9000D614A6 /* AlertNamespace.swift */,
+				63B12BAF2AAD9D3400D614A6 /* ButtonNamespace.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -134,7 +140,7 @@
 			isa = PBXGroup;
 			children = (
 				C739AE28284DF28600741E8F /* DiaryListViewController.swift */,
-				63E527382A9D97160000FBA6 /* CreateDiaryViewController.swift */,
+				63E527382A9D97160000FBA6 /* DiaryDetailViewContoller.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -319,12 +325,14 @@
 				63E527372A9D87660000FBA6 /* DiaryListTableViewCell.swift in Sources */,
 				C739AE2F284DF28600741E8F /* Diary.xcdatamodeld in Sources */,
 				63BB62B52AA182AA00524DCB /* CoreDataManager.swift in Sources */,
-				63E527392A9D97160000FBA6 /* CreateDiaryViewController.swift in Sources */,
+				63E527392A9D97160000FBA6 /* DiaryDetailViewContoller.swift in Sources */,
 				BABBDAE52A9F13A200D8D50B /* DecodingError.swift in Sources */,
 				BABBDB362AAD904100D8D50B /* CoreDataError.swift in Sources */,
 				BABBDB342AA6D05A00D8D50B /* ShareDisplayable.swift in Sources */,
+				63B12BB02AAD9D3400D614A6 /* ButtonNamespace.swift in Sources */,
 				63BB62B32AA181BE00524DCB /* Diary+CoreDataProperties.swift in Sources */,
 				BA1A55EB2A9D84AF0012C89D /* DiaryEntity.swift in Sources */,
+				63B12BAE2AAD9C9000D614A6 /* AlertNamespace.swift in Sources */,
 				63BB62B22AA181BE00524DCB /* Diary+CoreDataClass.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		459D493A878338290A3E0AEF /* Pods_Diary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDF8EB908CAD9D062C72898B /* Pods_Diary.framework */; };
 		63BB62822A9F109400524DCB /* DecodingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BB62812A9F109400524DCB /* DecodingManager.swift */; };
+		63BB62B22AA181BE00524DCB /* Diary+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BB62B02AA181BE00524DCB /* Diary+CoreDataClass.swift */; };
+		63BB62B32AA181BE00524DCB /* Diary+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BB62B12AA181BE00524DCB /* Diary+CoreDataProperties.swift */; };
+		63BB62B52AA182AA00524DCB /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BB62B42AA182AA00524DCB /* CoreDataManager.swift */; };
 		63E527352A9D7EBF0000FBA6 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 63E527342A9D7EBF0000FBA6 /* .swiftlint.yml */; };
 		63E527372A9D87660000FBA6 /* DiaryListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E527362A9D87660000FBA6 /* DiaryListTableViewCell.swift */; };
 		63E527392A9D97160000FBA6 /* CreateDiaryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E527382A9D97160000FBA6 /* CreateDiaryViewController.swift */; };
@@ -25,6 +28,9 @@
 
 /* Begin PBXFileReference section */
 		63BB62812A9F109400524DCB /* DecodingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodingManager.swift; sourceTree = "<group>"; };
+		63BB62B02AA181BE00524DCB /* Diary+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Diary+CoreDataClass.swift"; sourceTree = SOURCE_ROOT; };
+		63BB62B12AA181BE00524DCB /* Diary+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Diary+CoreDataProperties.swift"; sourceTree = SOURCE_ROOT; };
+		63BB62B42AA182AA00524DCB /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
 		63E527342A9D7EBF0000FBA6 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		63E527362A9D87660000FBA6 /* DiaryListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListTableViewCell.swift; sourceTree = "<group>"; };
 		63E527382A9D97160000FBA6 /* CreateDiaryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateDiaryViewController.swift; sourceTree = "<group>"; };
@@ -73,6 +79,14 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		63BB62B62AA185E700524DCB /* DataManager */ = {
+			isa = PBXGroup;
+			children = (
+				63BB62B42AA182AA00524DCB /* CoreDataManager.swift */,
+			);
+			path = DataManager;
+			sourceTree = "<group>";
+		};
 		63E5273C2A9ECD5A0000FBA6 /* App */ = {
 			isa = PBXGroup;
 			children = (
@@ -85,6 +99,8 @@
 		63E5273D2A9ECD660000FBA6 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				63BB62B02AA181BE00524DCB /* Diary+CoreDataClass.swift */,
+				63BB62B12AA181BE00524DCB /* Diary+CoreDataProperties.swift */,
 				BA1A55EA2A9D84AF0012C89D /* DiaryEntity.swift */,
 				63BB62812A9F109400524DCB /* DecodingManager.swift */,
 			);
@@ -147,6 +163,7 @@
 		C739AE23284DF28600741E8F /* Diary */ = {
 			isa = PBXGroup;
 			children = (
+				63BB62B62AA185E700524DCB /* DataManager */,
 				63E5273E2A9ECD800000FBA6 /* Extension */,
 				63E5273D2A9ECD660000FBA6 /* Model */,
 				BABBDAE62A9F13AE00D8D50B /* Error */,
@@ -283,9 +300,12 @@
 				BA1A55ED2A9D90810012C89D /* DateFormatter+.swift in Sources */,
 				63E527372A9D87660000FBA6 /* DiaryListTableViewCell.swift in Sources */,
 				C739AE2F284DF28600741E8F /* Diary.xcdatamodeld in Sources */,
+				63BB62B52AA182AA00524DCB /* CoreDataManager.swift in Sources */,
 				63E527392A9D97160000FBA6 /* CreateDiaryViewController.swift in Sources */,
 				BABBDAE52A9F13A200D8D50B /* DecodingError.swift in Sources */,
+				63BB62B32AA181BE00524DCB /* Diary+CoreDataProperties.swift in Sources */,
 				BA1A55EB2A9D84AF0012C89D /* DiaryEntity.swift in Sources */,
+				63BB62B22AA181BE00524DCB /* Diary+CoreDataClass.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		459D493A878338290A3E0AEF /* Pods_Diary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDF8EB908CAD9D062C72898B /* Pods_Diary.framework */; };
+		636B19AC2AA6C5E900B5242D /* AlertDisplayble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636B19AB2AA6C5E900B5242D /* AlertDisplayble.swift */; };
 		63BB62822A9F109400524DCB /* DecodingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BB62812A9F109400524DCB /* DecodingManager.swift */; };
 		63BB62B22AA181BE00524DCB /* Diary+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BB62B02AA181BE00524DCB /* Diary+CoreDataClass.swift */; };
 		63BB62B32AA181BE00524DCB /* Diary+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BB62B12AA181BE00524DCB /* Diary+CoreDataProperties.swift */; };
@@ -27,6 +28,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		636B19AB2AA6C5E900B5242D /* AlertDisplayble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertDisplayble.swift; sourceTree = "<group>"; };
 		63BB62812A9F109400524DCB /* DecodingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodingManager.swift; sourceTree = "<group>"; };
 		63BB62B02AA181BE00524DCB /* Diary+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Diary+CoreDataClass.swift"; sourceTree = SOURCE_ROOT; };
 		63BB62B12AA181BE00524DCB /* Diary+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Diary+CoreDataProperties.swift"; sourceTree = SOURCE_ROOT; };
@@ -77,6 +79,14 @@
 				EDF8EB908CAD9D062C72898B /* Pods_Diary.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		636B19AA2AA6C5C200B5242D /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				636B19AB2AA6C5E900B5242D /* AlertDisplayble.swift */,
+			);
+			path = Protocol;
 			sourceTree = "<group>";
 		};
 		63BB62B62AA185E700524DCB /* DataManager */ = {
@@ -163,6 +173,7 @@
 		C739AE23284DF28600741E8F /* Diary */ = {
 			isa = PBXGroup;
 			children = (
+				636B19AA2AA6C5C200B5242D /* Protocol */,
 				63BB62B62AA185E700524DCB /* DataManager */,
 				63E5273E2A9ECD800000FBA6 /* Extension */,
 				63E5273D2A9ECD660000FBA6 /* Model */,
@@ -296,6 +307,7 @@
 				C739AE29284DF28600741E8F /* DiaryListViewController.swift in Sources */,
 				C739AE25284DF28600741E8F /* AppDelegate.swift in Sources */,
 				C739AE27284DF28600741E8F /* SceneDelegate.swift in Sources */,
+				636B19AC2AA6C5E900B5242D /* AlertDisplayble.swift in Sources */,
 				63BB62822A9F109400524DCB /* DecodingManager.swift in Sources */,
 				BA1A55ED2A9D90810012C89D /* DateFormatter+.swift in Sources */,
 				63E527372A9D87660000FBA6 /* DiaryListTableViewCell.swift in Sources */,

--- a/Diary.xcodeproj/project.pbxproj
+++ b/Diary.xcodeproj/project.pbxproj
@@ -19,7 +19,8 @@
 		BA1A55EB2A9D84AF0012C89D /* DiaryEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1A55EA2A9D84AF0012C89D /* DiaryEntity.swift */; };
 		BA1A55ED2A9D90810012C89D /* DateFormatter+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1A55EC2A9D90810012C89D /* DateFormatter+.swift */; };
 		BABBDAE52A9F13A200D8D50B /* DecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABBDAE42A9F13A200D8D50B /* DecodingError.swift */; };
-		BABBDB342AA6D05A00D8D50B /* ShareDiary.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABBDB332AA6D05A00D8D50B /* ShareDiary.swift */; };
+		BABBDB342AA6D05A00D8D50B /* ShareDisplayable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABBDB332AA6D05A00D8D50B /* ShareDisplayable.swift */; };
+		BABBDB362AAD904100D8D50B /* CoreDataError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABBDB352AAD904100D8D50B /* CoreDataError.swift */; };
 		C739AE25284DF28600741E8F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C739AE24284DF28600741E8F /* AppDelegate.swift */; };
 		C739AE27284DF28600741E8F /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C739AE26284DF28600741E8F /* SceneDelegate.swift */; };
 		C739AE29284DF28600741E8F /* DiaryListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C739AE28284DF28600741E8F /* DiaryListViewController.swift */; };
@@ -41,7 +42,8 @@
 		BA1A55EA2A9D84AF0012C89D /* DiaryEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryEntity.swift; sourceTree = "<group>"; };
 		BA1A55EC2A9D90810012C89D /* DateFormatter+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+.swift"; sourceTree = "<group>"; };
 		BABBDAE42A9F13A200D8D50B /* DecodingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodingError.swift; sourceTree = "<group>"; };
-		BABBDB332AA6D05A00D8D50B /* ShareDiary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareDiary.swift; sourceTree = "<group>"; };
+		BABBDB332AA6D05A00D8D50B /* ShareDisplayable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareDisplayable.swift; sourceTree = "<group>"; };
+		BABBDB352AAD904100D8D50B /* CoreDataError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataError.swift; sourceTree = "<group>"; };
 		C739AE21284DF28600741E8F /* Diary.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Diary.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C739AE24284DF28600741E8F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C739AE26284DF28600741E8F /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -87,7 +89,7 @@
 			isa = PBXGroup;
 			children = (
 				636B19AB2AA6C5E900B5242D /* AlertDisplayble.swift */,
-				BABBDB332AA6D05A00D8D50B /* ShareDiary.swift */,
+				BABBDB332AA6D05A00D8D50B /* ShareDisplayable.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -150,6 +152,7 @@
 			isa = PBXGroup;
 			children = (
 				BABBDAE42A9F13A200D8D50B /* DecodingError.swift */,
+				BABBDB352AAD904100D8D50B /* CoreDataError.swift */,
 			);
 			path = Error;
 			sourceTree = "<group>";
@@ -318,7 +321,8 @@
 				63BB62B52AA182AA00524DCB /* CoreDataManager.swift in Sources */,
 				63E527392A9D97160000FBA6 /* CreateDiaryViewController.swift in Sources */,
 				BABBDAE52A9F13A200D8D50B /* DecodingError.swift in Sources */,
-				BABBDB342AA6D05A00D8D50B /* ShareDiary.swift in Sources */,
+				BABBDB362AAD904100D8D50B /* CoreDataError.swift in Sources */,
+				BABBDB342AA6D05A00D8D50B /* ShareDisplayable.swift in Sources */,
 				63BB62B32AA181BE00524DCB /* Diary+CoreDataProperties.swift in Sources */,
 				BA1A55EB2A9D84AF0012C89D /* DiaryEntity.swift in Sources */,
 				63BB62B22AA181BE00524DCB /* Diary+CoreDataClass.swift in Sources */,

--- a/Diary.xcodeproj/xcshareddata/xcschemes/Diary.xcscheme
+++ b/Diary.xcodeproj/xcshareddata/xcschemes/Diary.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C739AE20284DF28600741E8F"
+               BuildableName = "Diary.app"
+               BlueprintName = "Diary"
+               ReferencedContainer = "container:Diary.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C739AE20284DF28600741E8F"
+            BuildableName = "Diary.app"
+            BlueprintName = "Diary"
+            ReferencedContainer = "container:Diary.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C739AE20284DF28600741E8F"
+            BuildableName = "Diary.app"
+            BlueprintName = "Diary"
+            ReferencedContainer = "container:Diary.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Diary/App/AppDelegate.swift
+++ b/Diary/App/AppDelegate.swift
@@ -30,51 +30,5 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
-
-    // MARK: - Core Data stack
-
-    lazy var persistentContainer: NSPersistentContainer = {
-        /*
-         The persistent container for the application. This implementation
-         creates and returns a container, having loaded the store for the
-         application to it. This property is optional since there are legitimate
-         error conditions that could cause the creation of the store to fail.
-        */
-        let container = NSPersistentContainer(name: "Diary")
-        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
-            if let error = error as NSError? {
-                // Replace this implementation with code to handle the error appropriately.
-                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-                 
-                /*
-                 Typical reasons for an error here include:
-                 * The parent directory does not exist, cannot be created, or disallows writing.
-                 * The persistent store is not accessible, due to permissions or data protection when the device is locked.
-                 * The device is out of space.
-                 * The store could not be migrated to the current model version.
-                 Check the error message to determine what the actual problem was.
-                 */
-                fatalError("Unresolved error \(error), \(error.userInfo)")
-            }
-        })
-        return container
-    }()
-
-    // MARK: - Core Data Saving support
-
-    func saveContext () {
-        let context = persistentContainer.viewContext
-        if context.hasChanges {
-            do {
-                try context.save()
-            } catch {
-                // Replace this implementation with code to handle the error appropriately.
-                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-                let nserror = error as NSError
-                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
-            }
-        }
-    }
-
 }
 

--- a/Diary/App/SceneDelegate.swift
+++ b/Diary/App/SceneDelegate.swift
@@ -49,7 +49,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // to restore the scene back to its current state.
 
         // Save changes in the application's managed object context when the application transitions to the background.
-        (UIApplication.shared.delegate as? AppDelegate)?.saveContext()
+//        (UIApplication.shared.delegate as? AppDelegate)?.saveContext()
     }
 
 

--- a/Diary/App/SceneDelegate.swift
+++ b/Diary/App/SceneDelegate.swift
@@ -49,7 +49,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // to restore the scene back to its current state.
 
         // Save changes in the application's managed object context when the application transitions to the background.
-//        (UIApplication.shared.delegate as? AppDelegate)?.saveContext()
+        CoreDataManager.shared.saveContext()
     }
 
 

--- a/Diary/App/SceneDelegate.swift
+++ b/Diary/App/SceneDelegate.swift
@@ -49,7 +49,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // to restore the scene back to its current state.
 
         // Save changes in the application's managed object context when the application transitions to the background.
-        CoreDataManager.shared.saveContext()
+        do {
+            try CoreDataManager.shared.saveContext()
+        } catch {
+            fatalError(CoreDataError.saveFailure.message)
+        }
     }
 
 

--- a/Diary/Controller/CreateDiaryViewController.swift
+++ b/Diary/Controller/CreateDiaryViewController.swift
@@ -22,8 +22,8 @@ final class CreateDiaryViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        createDiary()
         configureUI()
+        setupDiaryData()
         setupNotification()
     }
     
@@ -36,6 +36,7 @@ final class CreateDiaryViewController: UIViewController {
     private func configureUI() {
         view.backgroundColor = .systemBackground
         self.title = DateFormatter().formatToString(from: Date(), with: "YYYY년 MM월 dd일")
+        
         view.addSubview(textView)
         
         NSLayoutConstraint.activate([
@@ -44,6 +45,14 @@ final class CreateDiaryViewController: UIViewController {
             textView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
             textView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
         ])
+    }
+    
+    private func setupDiaryData() {
+        if let diaryEdit = diary {
+            textView.text = "\(diaryEdit.title ?? "")\n\(diaryEdit.body ?? "")"
+        } else {
+            diary = CoreDataManager.shared.createDiary()
+        }
     }
     
     private func setupNotification() {
@@ -72,14 +81,6 @@ final class CreateDiaryViewController: UIViewController {
         saveDiary()
     }
     
-    private func createDiary() {
-        let newDiary = Diary(context: container.viewContext)
-        newDiary.id = UUID()
-        newDiary.createdAt = Date()
-        
-        diary = newDiary
-    }
-    
     private func saveDiary() {
         let contents = textView.text.split(separator: "\n")
         guard !contents.isEmpty,
@@ -87,12 +88,11 @@ final class CreateDiaryViewController: UIViewController {
         
         let body = contents.dropFirst().joined(separator: "\n")
         
-        guard let diary else { return }
-        
-        diary.title = "\(title)"
-        diary.body = body
-        
-        CoreDataManager.shared.saveContext()
+        CoreDataManager.shared.saveDiary(title: "\(title)", body: body, diary: diary)
+    }
+    
+    private func deleteDiary(_ diary: Diary?) {
+        CoreDataManager.shared.deleteDiary(diary)
     }
     
     deinit {

--- a/Diary/Controller/CreateDiaryViewController.swift
+++ b/Diary/Controller/CreateDiaryViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class CreateDiaryViewController: UIViewController, AlertDisplayable {
+final class CreateDiaryViewController: UIViewController, AlertDisplayable, ShareDiary {
     private let textView: UITextView = {
         let textView = UITextView()
         textView.translatesAutoresizingMaskIntoConstraints = false
@@ -15,17 +15,17 @@ final class CreateDiaryViewController: UIViewController, AlertDisplayable {
         
         return textView
     }()
-    
-    weak var delegate: DiaryListDelegate?
+
     private let container = CoreDataManager.shared.persistentContainer
     var diary: Diary?
     
-    init(_ diary: Diary? = nil) {
-        if diary == nil {
-            self.diary = CoreDataManager.shared.createDiary()
-        } else {
-            self.diary = diary
-        }
+    init() {
+        self.diary = CoreDataManager.shared.createDiary()
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    init(_ diary: Diary) {
+        self.diary = diary
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -36,7 +36,7 @@ final class CreateDiaryViewController: UIViewController, AlertDisplayable {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
-        configureTextView()
+        setupBodyText()
         setupNavigationBarButton()
         setupNotification()
     }
@@ -51,11 +51,6 @@ final class CreateDiaryViewController: UIViewController, AlertDisplayable {
     private func configureUI() {
         view.backgroundColor = .systemBackground
         self.title = DateFormatter().formatToString(from: Date(), with: "YYYY년 MM월 dd일")
-        
-    }
-    
-    private func configureTextView() {
-        textView.text = "\(diary?.title ?? "")\n\(diary?.body ?? "")"
         view.addSubview(textView)
         
         NSLayoutConstraint.activate([
@@ -64,6 +59,16 @@ final class CreateDiaryViewController: UIViewController, AlertDisplayable {
             textView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
             textView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
         ])
+    }
+    
+    private func setupBodyText() {
+        guard let diary,
+              let title = diary.title,
+              let body = diary.body else {
+            return
+        }
+        
+        textView.text = "\(title)\n\(body)"
     }
     
     private func setupNavigationBarButton() {
@@ -134,7 +139,7 @@ extension CreateDiaryViewController {
         
         let shareAction = UIAlertAction(title: "Share...", style: .default) { [weak self] _ in
             guard let self else { return }
-            self.delegate?.shareDiary(self.diary)
+            self.shareDiary(self.diary)
         }
         
         let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)

--- a/Diary/Controller/CreateDiaryViewController.swift
+++ b/Diary/Controller/CreateDiaryViewController.swift
@@ -141,6 +141,7 @@ extension CreateDiaryViewController {
     }
 }
 
+// MARK: - UITextViewDelegate
 extension CreateDiaryViewController: UITextViewDelegate {
     func textViewDidEndEditing(_ textView: UITextView) {
         let contents = textView.text.split(separator: "\n")

--- a/Diary/Controller/CreateDiaryViewController.swift
+++ b/Diary/Controller/CreateDiaryViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class CreateDiaryViewController: UIViewController {
+final class CreateDiaryViewController: UIViewController, AlertDisplayable {
     private let textView: UITextView = {
         let textView = UITextView()
         textView.translatesAutoresizingMaskIntoConstraints = false
@@ -76,8 +76,6 @@ final class CreateDiaryViewController: UIViewController {
     }
     
     private func showDeleteAlert() {
-        let alertController = UIAlertController(title: "진짜요?", message: "정말로 삭제하시겠어요?", preferredStyle: .alert)
-        
         let cancelAction = UIAlertAction(title: "취소", style: .cancel)
         let deleteAction = UIAlertAction(title: "삭제", style: .destructive) { [weak self] _ in
             guard let self else { return }
@@ -86,10 +84,7 @@ final class CreateDiaryViewController: UIViewController {
             self.navigationController?.popViewController(animated: true)
         }
         
-        alertController.addAction(cancelAction)
-        alertController.addAction(deleteAction)
-        
-        present(alertController, animated: true)
+        showAlert(title: "진짜요?", message: "정말로 삭제하시겠어요?", actions: [cancelAction, deleteAction])
     }
     
     private func saveDiary() {

--- a/Diary/Controller/CreateDiaryViewController.swift
+++ b/Diary/Controller/CreateDiaryViewController.swift
@@ -15,10 +15,10 @@ final class CreateDiaryViewController: UIViewController, AlertDisplayable, Share
         
         return textView
     }()
-
+    
     private let container = CoreDataManager.shared.persistentContainer
-    var diary: Diary
-    var isNew: Bool
+    private var diary: Diary
+    private var isNew: Bool
     
     init() {
         self.diary = CoreDataManager.shared.createDiary()
@@ -43,7 +43,7 @@ final class CreateDiaryViewController: UIViewController, AlertDisplayable, Share
         setupNavigationBarButton()
         setupNotification()
     }
-
+    
     private func configureUI() {
         view.backgroundColor = .systemBackground
         self.title = DateFormatter().formatToString(from: Date(), with: "YYYY년 MM월 dd일")
@@ -75,7 +75,7 @@ final class CreateDiaryViewController: UIViewController, AlertDisplayable, Share
         let moreButton = UIBarButtonItem(title: "더보기", style: .plain, target: self, action: #selector(showMoreOptions))
         navigationItem.rightBarButtonItem = moreButton
     }
-
+    
     private func setupNotification() {
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(keyboardWillShow),
@@ -94,13 +94,13 @@ final class CreateDiaryViewController: UIViewController, AlertDisplayable, Share
         let cancelAction = UIAlertAction(title: "취소", style: .cancel)
         let deleteAction = UIAlertAction(title: "삭제", style: .destructive) { [weak self] _ in
             guard let self else { return }
-            CoreDataManager.shared.deleteDiary(diary)
+            CoreDataManager.shared.deleteDiary(self.diary)
             self.navigationController?.popViewController(animated: true)
         }
         
         showAlert(title: "진짜요?", message: "정말로 삭제하시겠어요?", actions: [cancelAction, deleteAction])
     }
-
+    
     deinit {
         NotificationCenter.default.removeObserver(self)
     }

--- a/Diary/Controller/CreateDiaryViewController.swift
+++ b/Diary/Controller/CreateDiaryViewController.swift
@@ -151,7 +151,7 @@ extension CreateDiaryViewController: UITextViewDelegate {
     }
     
     func textViewDidChange(_ textView: UITextView) {
-        let contents = textView.text.split(separator: "\n")
+        let contents = textView.text.components(separatedBy: "\n")
         guard !contents.isEmpty,
               let title = contents.first else { return }
         

--- a/Diary/Controller/DiaryDetailViewContoller.swift
+++ b/Diary/Controller/DiaryDetailViewContoller.swift
@@ -1,5 +1,5 @@
 //
-//  CreateDiaryViewController.swift
+//  DiaryDetailViewContoller.swift
 //  Diary
 //
 //  Created by Maxhyunm, Hamg on 2023/08/29.
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class CreateDiaryViewController: UIViewController, AlertDisplayable, ShareDisplayable {
+final class DiaryDetailViewContoller: UIViewController, AlertDisplayable, ShareDisplayable {
     private let textView: UITextView = {
         let textView = UITextView()
         textView.translatesAutoresizingMaskIntoConstraints = false
@@ -72,7 +72,10 @@ final class CreateDiaryViewController: UIViewController, AlertDisplayable, Share
     }
     
     private func setupNavigationBarButton() {
-        let moreButton = UIBarButtonItem(title: "더보기", style: .plain, target: self, action: #selector(showMoreOptions))
+        let moreButton = UIBarButtonItem(title: ButtonNamespace.more,
+                                         style: .plain,
+                                         target: self,
+                                         action: #selector(showMoreOptions))
         navigationItem.rightBarButtonItem = moreButton
     }
     
@@ -91,26 +94,31 @@ final class CreateDiaryViewController: UIViewController, AlertDisplayable, Share
     }
     
     private func showDeleteAlert() {
-        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
-        let deleteAction = UIAlertAction(title: "삭제", style: .destructive) { [weak self] _ in
+        let cancelAction = UIAlertAction(title: ButtonNamespace.cancel, style: .cancel)
+        let deleteAction = UIAlertAction(title: ButtonNamespace.delete, style: .destructive) { [weak self] _ in
             guard let self else { return }
             do {
                 try CoreDataManager.shared.deleteDiary(self.diary)
                 self.navigationController?.popViewController(animated: true)
             } catch CoreDataError.deleteFailure {
-                let cancelAction = UIAlertAction(title: "확인", style: .cancel)
+                let cancelAction = UIAlertAction(title: ButtonNamespace.confirm, style: .cancel)
                 self.showAlert(title: CoreDataError.deleteFailure.alertTitle,
                                message: CoreDataError.deleteFailure.message,
-                               actions: [cancelAction])
+                               actions: [cancelAction],
+                               preferredStyle: .alert)
             } catch {
-                let cancelAction = UIAlertAction(title: "확인", style: .cancel)
+                let cancelAction = UIAlertAction(title: ButtonNamespace.confirm, style: .cancel)
                 self.showAlert(title: CoreDataError.deleteFailure.alertTitle,
                                message: CoreDataError.unknown.message,
-                               actions: [cancelAction])
+                               actions: [cancelAction],
+                               preferredStyle: .alert)
             }
         }
         
-        showAlert(title: "진짜요?", message: "정말로 삭제하시겠어요?", actions: [cancelAction, deleteAction])
+        showAlert(title: AlertNamespace.deleteTitle,
+                  message: AlertNamespace.deleteMessage,
+                  actions: [cancelAction, deleteAction],
+                  preferredStyle: .alert)
     }
     
     deinit {
@@ -118,7 +126,7 @@ final class CreateDiaryViewController: UIViewController, AlertDisplayable, Share
     }
 }
 
-extension CreateDiaryViewController {
+extension DiaryDetailViewContoller {
     @objc private func keyboardWillShow(_ notification: Notification) {
         guard let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey]
                 as? CGRect else { return }
@@ -129,17 +137,17 @@ extension CreateDiaryViewController {
     @objc private func showMoreOptions() {
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         
-        let deleteAction = UIAlertAction(title: "Delete", style: .destructive) { [weak self] _ in
+        let deleteAction = UIAlertAction(title: ButtonNamespace.deleteEnglish, style: .destructive) { [weak self] _ in
             guard let self else { return }
             self.showDeleteAlert()
         }
         
-        let shareAction = UIAlertAction(title: "Share...", style: .default) { [weak self] _ in
+        let shareAction = UIAlertAction(title: ButtonNamespace.shareEnglish, style: .default) { [weak self] _ in
             guard let self else { return }
             self.shareDiary(self.diary)
         }
         
-        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
+        let cancelAction = UIAlertAction(title: ButtonNamespace.cancelEnglish, style: .cancel)
         
         alertController.addAction(shareAction)
         alertController.addAction(deleteAction)
@@ -153,7 +161,7 @@ extension CreateDiaryViewController {
     }
 }
 
-extension CreateDiaryViewController: UITextViewDelegate {
+extension DiaryDetailViewContoller: UITextViewDelegate {
     func textViewDidEndEditing(_ textView: UITextView) {
         let contents = textView.text.split(separator: "\n")
         guard !contents.isEmpty else { return }
@@ -161,15 +169,17 @@ extension CreateDiaryViewController: UITextViewDelegate {
         do {
             try CoreDataManager.shared.saveContext()
         } catch CoreDataError.saveFailure {
-            let cancelAction = UIAlertAction(title: "확인", style: .cancel)
+            let cancelAction = UIAlertAction(title: ButtonNamespace.confirm, style: .cancel)
             self.showAlert(title: CoreDataError.saveFailure.alertTitle,
                            message: CoreDataError.saveFailure.message,
-                           actions: [cancelAction])
+                           actions: [cancelAction],
+                           preferredStyle: .alert)
         } catch {
-            let cancelAction = UIAlertAction(title: "확인", style: .cancel)
+            let cancelAction = UIAlertAction(title: ButtonNamespace.confirm, style: .cancel)
             self.showAlert(title: CoreDataError.saveFailure.alertTitle,
                            message: CoreDataError.unknown.message,
-                           actions: [cancelAction])
+                           actions: [cancelAction],
+                           preferredStyle: .alert)
         }
     }
     

--- a/Diary/Controller/DiaryListViewController.swift
+++ b/Diary/Controller/DiaryListViewController.swift
@@ -83,6 +83,12 @@ extension DiaryListViewController: UITableViewDataSource, UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
+        let diaryToEdit = diaryList[indexPath.row]
+        let createVC = CreateDiaryViewController()
+        
+        createVC.delegate = self
+        createVC.diary = diaryToEdit
+        navigationController?.pushViewController(createVC, animated: true)
     }
 }
 

--- a/Diary/Controller/DiaryListViewController.swift
+++ b/Diary/Controller/DiaryListViewController.swift
@@ -90,6 +90,31 @@ extension DiaryListViewController: UITableViewDataSource, UITableViewDelegate {
         createVC.diary = diaryToEdit
         navigationController?.pushViewController(createVC, animated: true)
     }
+    
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) ->
+    UISwipeActionsConfiguration? {
+        let delete = UIContextualAction(style: .normal, title: "") { (_, _, success: @escaping (Bool) -> Void) in
+            let selectedDiary = self.diaryList[indexPath.row]
+            
+            CoreDataManager.shared.deleteDiary(selectedDiary)
+            self.readCoreData()
+            success(true)
+        }
+        
+        let share = UIContextualAction(style: .normal, title: "") { (_, _, success: @escaping (Bool) -> Void) in
+            let selectedDiary = self.diaryList[indexPath.row]
+            
+            self.shareDiary(selectedDiary)
+            success(true)
+        }
+        
+        delete.backgroundColor = .systemRed
+        delete.image = UIImage(systemName: "trash.fill")
+        share.backgroundColor = .systemBlue
+        share.image = UIImage(systemName: "square.and.arrow.up")
+        
+        return UISwipeActionsConfiguration(actions: [delete, share])
+    }
 }
 
 extension DiaryListViewController: DiaryListDelegate {
@@ -100,5 +125,21 @@ extension DiaryListViewController: DiaryListDelegate {
         } catch {
             // TODO : AlertController Error
         }
+    }
+    
+    func shareDiary(_ diary: Diary?) {
+        guard let diary,
+              let title = diary.title,
+              let createdAt = diary.createdAt,
+              let body = diary.body else {
+            return
+        }
+        
+        let date = dateFormatter.formatToString(from: createdAt, with: "YYYY년 MM월 dd일")
+        let shareText = "제목: \(title)\n작성일자: \(date)\n내용: \(body)"
+        let activityViewController = UIActivityViewController(activityItems: [shareText], applicationActivities: nil)
+        activityViewController.popoverPresentationController?.sourceView = self.view
+        
+        self.present(activityViewController, animated: true, completion: nil)
     }
 }

--- a/Diary/Controller/DiaryListViewController.swift
+++ b/Diary/Controller/DiaryListViewController.swift
@@ -66,7 +66,7 @@ final class DiaryListViewController: UIViewController {
 extension DiaryListViewController: AlertDisplayable {
     private func readCoreData() {
         do {
-            let fetchedDiaries = try container.viewContext.fetch(Diary.fetchRequest())
+            let fetchedDiaries = try CoreDataManager.shared.fetchDiary()
             diaryList = fetchedDiaries.filter { $0.title != nil }
             tableView.reloadData()
         } catch {

--- a/Diary/Controller/DiaryListViewController.swift
+++ b/Diary/Controller/DiaryListViewController.swift
@@ -8,6 +8,7 @@ import UIKit
 
 protocol DiaryListDelegate: AnyObject {
     func readCoreData()
+    func shareDiary(_ diary: Diary?)
 }
 
 final class DiaryListViewController: UIViewController {

--- a/Diary/Controller/DiaryListViewController.swift
+++ b/Diary/Controller/DiaryListViewController.swift
@@ -28,21 +28,19 @@ final class DiaryListViewController: UIViewController {
 
         readCoreData()
         configureUI()
+        setupNavigationBarButton()
         setupTableView()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        readCoreData()
     }
     
     private func configureUI() {
         view.backgroundColor = .systemBackground
         self.title = "일기장"
-        
-        let addDiary = UIAction(image: UIImage(systemName: "plus")) { [weak self] _ in
-            guard let self else { return }
-            let createDiaryView = CreateDiaryViewController()
-            createDiaryView.delegate = self
-            self.navigationController?.pushViewController(createDiaryView, animated: true)
-        }
-        
-        navigationItem.rightBarButtonItem = UIBarButtonItem(primaryAction: addDiary)
         
         view.addSubview(tableView)
         
@@ -52,6 +50,17 @@ final class DiaryListViewController: UIViewController {
             tableView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
             tableView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
         ])
+    }
+    
+    private func setupNavigationBarButton() {
+        let addDiary = UIAction(image: UIImage(systemName: "plus")) { [weak self] _ in
+            guard let self else { return }
+            let createDiaryView = CreateDiaryViewController()
+            createDiaryView.delegate = self
+            self.navigationController?.pushViewController(createDiaryView, animated: true)
+        }
+        
+        navigationItem.rightBarButtonItem = UIBarButtonItem(primaryAction: addDiary)
     }
     
     private func setupTableView() {
@@ -85,10 +94,9 @@ extension DiaryListViewController: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         let diaryToEdit = diaryList[indexPath.row]
-        let createVC = CreateDiaryViewController()
+        let createVC = CreateDiaryViewController(diaryToEdit)
         
         createVC.delegate = self
-        createVC.diary = diaryToEdit
         navigationController?.pushViewController(createVC, animated: true)
     }
     

--- a/Diary/Controller/DiaryListViewController.swift
+++ b/Diary/Controller/DiaryListViewController.swift
@@ -49,7 +49,7 @@ final class DiaryListViewController: UIViewController {
     private func setupNavigationBarButton() {
         let addDiary = UIAction(image: UIImage(systemName: "plus")) { [weak self] _ in
             guard let self else { return }
-            let createDiaryView = CreateDiaryViewController()
+            let createDiaryView = DiaryDetailViewContoller()
             self.navigationController?.pushViewController(createDiaryView, animated: true)
         }
         
@@ -70,15 +70,17 @@ extension DiaryListViewController: AlertDisplayable {
             diaryList = fetchedDiaries.filter { $0.title != nil }
             tableView.reloadData()
         } catch CoreDataError.dataNotFound {
-            let cancelAction = UIAlertAction(title: "확인", style: .cancel)
+            let cancelAction = UIAlertAction(title: ButtonNamespace.confirm, style: .cancel)
             showAlert(title: CoreDataError.dataNotFound.alertTitle,
                       message: CoreDataError.dataNotFound.message,
-                      actions: [cancelAction])
+                      actions: [cancelAction],
+                      preferredStyle: .alert)
         } catch {
-            let cancelAction = UIAlertAction(title: "확인", style: .cancel)
+            let cancelAction = UIAlertAction(title: ButtonNamespace.confirm, style: .cancel)
             showAlert(title: CoreDataError.dataNotFound.alertTitle,
                       message: CoreDataError.unknown.message,
-                      actions: [cancelAction])
+                      actions: [cancelAction],
+                      preferredStyle: .alert)
         }
     }
 }
@@ -111,7 +113,7 @@ extension DiaryListViewController: UITableViewDelegate, ShareDisplayable {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         let diaryToEdit = diaryList[indexPath.row]
-        let createVC = CreateDiaryViewController(diaryToEdit)
+        let createVC = DiaryDetailViewContoller(diaryToEdit)
         
         navigationController?.pushViewController(createVC, animated: true)
     }
@@ -125,15 +127,17 @@ extension DiaryListViewController: UITableViewDelegate, ShareDisplayable {
                 self.readCoreData()
                 success(true)
             } catch CoreDataError.deleteFailure {
-                let cancelAction = UIAlertAction(title: "확인", style: .cancel)
+                let cancelAction = UIAlertAction(title: ButtonNamespace.confirm, style: .cancel)
                 self.showAlert(title: CoreDataError.deleteFailure.alertTitle,
                                message: CoreDataError.deleteFailure.message,
-                               actions: [cancelAction])
+                               actions: [cancelAction],
+                               preferredStyle: .alert)
             } catch {
-                let cancelAction = UIAlertAction(title: "확인", style: .cancel)
+                let cancelAction = UIAlertAction(title: ButtonNamespace.confirm, style: .cancel)
                 self.showAlert(title: CoreDataError.deleteFailure.alertTitle,
                                message: CoreDataError.unknown.message,
-                               actions: [cancelAction])
+                               actions: [cancelAction],
+                               preferredStyle: .alert)
             }
         }
         

--- a/Diary/Controller/DiaryListViewController.swift
+++ b/Diary/Controller/DiaryListViewController.swift
@@ -15,11 +15,14 @@ final class DiaryListViewController: UIViewController {
     }()
     private var diaryEntities = [DiaryEntity]()
     private let dateFormatter = DateFormatter()
+    private let container = CoreDataManager.shard.persistentContainer
+    private var diaryList = [Diary]()
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         setupData()
+        readCoreData()
         configureUI()
         setupTableView()
     }
@@ -63,13 +66,21 @@ final class DiaryListViewController: UIViewController {
         } catch {
             print(DecodingError.unknown.message)
         }
-        
+    }
+    
+    private func readCoreData() {
+        do {
+            let diaryList = try container.viewContext.fetch(Diary.fetchRequest())
+            tableView.reloadData()
+        } catch {
+            // TODO : AlertController Error
+        }
     }
 }
 
 extension DiaryListViewController: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        diaryEntities.count
+        diaryList.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -77,10 +88,13 @@ extension DiaryListViewController: UITableViewDataSource, UITableViewDelegate {
                                                        for: indexPath) as?
                 DiaryListTableViewCell else { return UITableViewCell() }
         
-        let diaryEntity = diaryEntities[indexPath.row]
-        let date = dateFormatter.formatToString(from: diaryEntity.createdAt, with: "YYYY년 MM월 dd일")
+        let diaryEntity = diaryList[indexPath.row]
+        guard let title = diaryEntity.title,
+              let createdAt = diaryEntity.createdAt,
+              let body = diaryEntity.body else { return UITableViewCell() }
+        let date = dateFormatter.formatToString(from: createdAt, with: "YYYY년 MM월 dd일")
         
-        cell.setModel(title: diaryEntity.title, date: date, body: diaryEntity.body)
+        cell.setModel(title: title, date: date, body: body)
         
         return cell
     }

--- a/Diary/Controller/DiaryListViewController.swift
+++ b/Diary/Controller/DiaryListViewController.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-final class DiaryListViewController: UIViewController, AlertDisplayable, ShareDiary {
+final class DiaryListViewController: UIViewController {
     private let tableView: UITableView = {
         let tableView = UITableView()
         tableView.translatesAutoresizingMaskIntoConstraints = false
@@ -20,7 +20,7 @@ final class DiaryListViewController: UIViewController, AlertDisplayable, ShareDi
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
         configureUI()
         setupNavigationBarButton()
         setupTableView()
@@ -61,7 +61,9 @@ final class DiaryListViewController: UIViewController, AlertDisplayable, ShareDi
         tableView.delegate = self
         tableView.register(DiaryListTableViewCell.self, forCellReuseIdentifier: DiaryListTableViewCell.identifier)
     }
-    
+}
+
+extension DiaryListViewController: AlertDisplayable {
     private func readCoreData() {
         do {
             let fetchedDiaries = try container.viewContext.fetch(Diary.fetchRequest())
@@ -74,7 +76,7 @@ final class DiaryListViewController: UIViewController, AlertDisplayable, ShareDi
     }
 }
 
-extension DiaryListViewController: UITableViewDataSource, UITableViewDelegate {
+extension DiaryListViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         diaryList.count
     }
@@ -94,12 +96,14 @@ extension DiaryListViewController: UITableViewDataSource, UITableViewDelegate {
         
         return cell
     }
-    
+}
+
+extension DiaryListViewController: UITableViewDelegate, ShareDiary {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         let diaryToEdit = diaryList[indexPath.row]
         let createVC = CreateDiaryViewController(diaryToEdit)
-
+        
         navigationController?.pushViewController(createVC, animated: true)
     }
     

--- a/Diary/Controller/DiaryListViewController.swift
+++ b/Diary/Controller/DiaryListViewController.swift
@@ -118,13 +118,14 @@ extension DiaryListViewController: UITableViewDataSource, UITableViewDelegate {
     }
 }
 
-extension DiaryListViewController: DiaryListDelegate {
+extension DiaryListViewController: DiaryListDelegate, AlertDisplayable {
     func readCoreData() {
         do {
             diaryList = try container.viewContext.fetch(Diary.fetchRequest())
             tableView.reloadData()
         } catch {
-            // TODO : AlertController Error
+            let cancelAction = UIAlertAction(title: "확인", style: .cancel)
+            showAlert(title: "로드 실패", message: "데이터를 불러오지 못했습니다.", actions: [cancelAction])
         }
     }
     

--- a/Diary/Controller/DiaryListViewController.swift
+++ b/Diary/Controller/DiaryListViewController.swift
@@ -89,7 +89,9 @@ extension DiaryListViewController: UITableViewDataSource {
         let diaryEntity = diaryList[indexPath.row]
         guard let title = diaryEntity.title,
               let createdAt = diaryEntity.createdAt,
-              let body = diaryEntity.body else { return UITableViewCell() }
+              let body = diaryEntity.body?.split(separator: "\n").joined(separator: "\n") else {
+            return UITableViewCell()
+        }
         let date = dateFormatter.formatToString(from: createdAt, with: "YYYY년 MM월 dd일")
         
         cell.setModel(title: title, date: date, body: body)

--- a/Diary/DataManager/CoreDataManager.swift
+++ b/Diary/DataManager/CoreDataManager.swift
@@ -10,6 +10,15 @@ import CoreData
 class CoreDataManager {
     static let shared = CoreDataManager()
     private init() {}
+        
+    func fetchDiary() throws -> [Diary] {
+        let request: NSFetchRequest<Diary> = Diary.fetchRequest()
+        let sortByDate = NSSortDescriptor(key: "createdAt", ascending: false)
+        request.sortDescriptors = [sortByDate]
+        
+        let diaries = try persistentContainer.viewContext.fetch(request)
+        return diaries
+    }
     
     func createDiary() -> Diary {
         let newDiary = Diary(context: persistentContainer.viewContext)

--- a/Diary/DataManager/CoreDataManager.swift
+++ b/Diary/DataManager/CoreDataManager.swift
@@ -9,7 +9,7 @@ import Foundation
 import CoreData
 
 class CoreDataManager {
-    static let shard = CoreDataManager()
+    static let shared = CoreDataManager()
     private init() {}
     
     // MARK: - Core Data stack

--- a/Diary/DataManager/CoreDataManager.swift
+++ b/Diary/DataManager/CoreDataManager.swift
@@ -11,20 +11,12 @@ class CoreDataManager {
     static let shared = CoreDataManager()
     private init() {}
     
-    func createDiary() -> Diary? {
+    func createDiary() -> Diary {
         let newDiary = Diary(context: persistentContainer.viewContext)
         newDiary.id = UUID()
         newDiary.createdAt = Date()
         
         return newDiary
-    }
-    
-    func saveDiary(title: String, body: String, diary: Diary?) {
-        guard let diary else { return }
-        diary.title = title
-        diary.body = body
-        
-        saveContext()
     }
     
     func deleteDiary(_ diary: Diary?) {

--- a/Diary/DataManager/CoreDataManager.swift
+++ b/Diary/DataManager/CoreDataManager.swift
@@ -12,6 +12,29 @@ class CoreDataManager {
     static let shared = CoreDataManager()
     private init() {}
     
+    func createDiary() -> Diary? {
+        let newDiary = Diary(context: persistentContainer.viewContext)
+        newDiary.id = UUID()
+        newDiary.createdAt = Date()
+        
+        return newDiary
+    }
+    
+    func saveDiary(title: String, body: String, diary: Diary?) {
+        guard let diary else { return }
+        diary.title = title
+        diary.body = body
+        
+        saveContext()
+    }
+    
+    func deleteDiary(_ diary: Diary?) {
+        if let diary = diary {
+            persistentContainer.viewContext.delete(diary)
+            saveContext()
+        }
+    }
+    
     // MARK: - Core Data stack
     lazy var persistentContainer: NSPersistentContainer = {
         let container = NSPersistentContainer(name: "Diary")

--- a/Diary/DataManager/CoreDataManager.swift
+++ b/Diary/DataManager/CoreDataManager.swift
@@ -1,0 +1,38 @@
+//
+//  CoreDataManager.swift
+//  Diary
+//
+//  Created by Max, Hemg on 2023/09/01.
+//
+
+import Foundation
+import CoreData
+
+class CoreDataManager {
+    static let shard = CoreDataManager()
+    private init() {}
+    
+    // MARK: - Core Data stack
+    lazy var persistentContainer: NSPersistentContainer = {
+        let container = NSPersistentContainer(name: "Diary")
+        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+            if let error = error as NSError? {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+        return container
+    }()
+
+    // MARK: - Core Data Saving support
+    func saveContext () {
+        let context = persistentContainer.viewContext
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                let nserror = error as NSError
+                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
+            }
+        }
+    }
+}

--- a/Diary/DataManager/CoreDataManager.swift
+++ b/Diary/DataManager/CoreDataManager.swift
@@ -5,7 +5,6 @@
 //  Created by Max, Hemg on 2023/09/01.
 //
 
-import Foundation
 import CoreData
 
 class CoreDataManager {

--- a/Diary/DataManager/CoreDataManager.swift
+++ b/Diary/DataManager/CoreDataManager.swift
@@ -15,7 +15,7 @@ class CoreDataManager {
     // MARK: - Core Data stack
     lazy var persistentContainer: NSPersistentContainer = {
         let container = NSPersistentContainer(name: "Diary")
-        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+        container.loadPersistentStores(completionHandler: { (_, error) in
             if let error = error as NSError? {
                 fatalError("Unresolved error \(error), \(error.userInfo)")
             }

--- a/Diary/Diary.xcdatamodeld/Diary.xcdatamodel/contents
+++ b/Diary/Diary.xcdatamodeld/Diary.xcdatamodel/contents
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="1" systemVersion="11A491" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="false" userDefinedModelVersionIdentifier="">
-    <elements/>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21279" systemVersion="22D49" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Diary" representedClassName="Diary" syncable="YES">
+        <attribute name="body" optional="YES" attributeType="String"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+    </entity>
 </model>

--- a/Diary/Error/CoreDataError.swift
+++ b/Diary/Error/CoreDataError.swift
@@ -1,0 +1,39 @@
+//
+//  CoreDataError.swift
+//  Diary
+//
+//  Created by Max, Hemg on 2023/09/10.
+//
+
+enum CoreDataError: Error {
+    case dataNotFound
+    case saveFailure
+    case deleteFailure
+    case unknown
+    
+    var alertTitle: String {
+        switch self {
+        case .dataNotFound:
+            return "로드 실패"
+        case .saveFailure:
+            return "저장 실패"
+        case .deleteFailure:
+            return "삭제 실패"
+        case .unknown:
+            return "오류"
+        }
+    }
+
+    var message: String {
+        switch self {
+        case .dataNotFound:
+            return "데이터를 찾지 못했습니다."
+        case .saveFailure:
+            return "저장에 실패하였습니다."
+        case .deleteFailure:
+            return "삭제에 실패하였습니다."
+        case .unknown:
+            return "알 수 없는 오류입니다."
+        }
+    }
+}

--- a/Diary/Error/DecodingError.swift
+++ b/Diary/Error/DecodingError.swift
@@ -2,7 +2,7 @@
 //  Error.swift
 //  Diary
 //
-//  Created by Min Hyun on 2023/08/30.
+//  Created by Max, Hemg on 2023/08/30.
 //
 
 enum DecodingError: Error {

--- a/Diary/Model/AlertNamespace.swift
+++ b/Diary/Model/AlertNamespace.swift
@@ -1,0 +1,11 @@
+//
+//  AlertNamespace.swift
+//  Diary
+//
+//  Created by Maxhyunm, Hamg on 2023/09/10.
+//
+
+enum AlertNamespace {
+    static let deleteTitle = "진짜요?"
+    static let deleteMessage = "정말로 삭제하시겠어요?"
+}

--- a/Diary/Model/ButtonNamespace.swift
+++ b/Diary/Model/ButtonNamespace.swift
@@ -1,0 +1,16 @@
+//
+//  ButtonNamespace.swift
+//  Diary
+//
+//  Created by Maxhyunm, Hamg on 2023/09/10.
+//
+
+enum ButtonNamespace {
+    static let more = "더보기"
+    static let cancel = "취소"
+    static let delete = "삭제"
+    static let confirm = "확인"
+    static let deleteEnglish = "Delete"
+    static let shareEnglish = "Share..."
+    static let cancelEnglish = "Cancel"
+}

--- a/Diary/Protocol/AlertDisplayble.swift
+++ b/Diary/Protocol/AlertDisplayble.swift
@@ -2,7 +2,7 @@
 //  AlertDisplayble.swift
 //  Diary
 //
-//  Created by 1 on 2023/09/05.
+//  Created by Max, Hemg on 2023/09/05.
 //
 
 import UIKit

--- a/Diary/Protocol/AlertDisplayble.swift
+++ b/Diary/Protocol/AlertDisplayble.swift
@@ -1,0 +1,8 @@
+//
+//  AlertDisplayble.swift
+//  Diary
+//
+//  Created by 1 on 2023/09/05.
+//
+
+import Foundation

--- a/Diary/Protocol/AlertDisplayble.swift
+++ b/Diary/Protocol/AlertDisplayble.swift
@@ -5,4 +5,17 @@
 //  Created by 1 on 2023/09/05.
 //
 
-import Foundation
+import UIKit
+
+protocol AlertDisplayable {
+    func showAlert(title: String?, message: String?, actions: [UIAlertAction])
+}
+
+extension AlertDisplayable where Self: UIViewController {
+    func showAlert(title: String?, message: String?, actions: [UIAlertAction]) {
+        let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        actions.forEach { alertController.addAction($0) }
+        
+        present(alertController, animated: true)
+    }
+}

--- a/Diary/Protocol/AlertDisplayble.swift
+++ b/Diary/Protocol/AlertDisplayble.swift
@@ -8,12 +8,15 @@
 import UIKit
 
 protocol AlertDisplayable {
-    func showAlert(title: String?, message: String?, actions: [UIAlertAction])
+    func showAlert(title: String?, message: String?, actions: [UIAlertAction], preferredStyle: UIAlertController.Style)
 }
 
 extension AlertDisplayable where Self: UIViewController {
-    func showAlert(title: String?, message: String?, actions: [UIAlertAction]) {
-        let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
+    func showAlert(title: String?,
+                   message: String?,
+                   actions: [UIAlertAction],
+                   preferredStyle: UIAlertController.Style) {
+        let alertController = UIAlertController(title: title, message: message, preferredStyle: preferredStyle)
         actions.forEach { alertController.addAction($0) }
         
         present(alertController, animated: true)

--- a/Diary/Protocol/ShareDiary.swift
+++ b/Diary/Protocol/ShareDiary.swift
@@ -1,0 +1,30 @@
+//
+//  ShareDiary.swift
+//  Diary
+//
+//  Created by Max, Hemg on 2023/09/05.
+//
+
+import UIKit
+
+protocol ShareDiary {
+    func shareDiary(_ diary: Diary?)
+}
+
+extension ShareDiary where Self: UIViewController {
+    func shareDiary(_ diary: Diary?) {
+        guard let diary,
+              let title = diary.title,
+              let createdAt = diary.createdAt,
+              let body = diary.body else {
+            return
+        }
+
+        let date = DateFormatter().formatToString(from: createdAt, with: "YYYY년 MM월 dd일")
+        let shareText = "제목: \(title)\n작성일자: \(date)\n내용: \(body)"
+        let activityViewController = UIActivityViewController(activityItems: [shareText], applicationActivities: nil)
+        activityViewController.popoverPresentationController?.sourceView = self.view
+
+        self.present(activityViewController, animated: true, completion: nil)
+    }
+}

--- a/Diary/Protocol/ShareDisplayable.swift
+++ b/Diary/Protocol/ShareDisplayable.swift
@@ -21,10 +21,14 @@ extension ShareDisplayable where Self: UIViewController {
         }
 
         let date = DateFormatter().formatToString(from: createdAt, with: "YYYY년 MM월 dd일")
-        let shareText = "제목: \(title)\n작성일자: \(date)\n내용: \(body)"
+        let shareText = """
+                        제목: \(title)
+                        작성일자: \(date)
+                        내용: \(body)
+                        """
         let activityViewController = UIActivityViewController(activityItems: [shareText], applicationActivities: nil)
         activityViewController.popoverPresentationController?.sourceView = self.view
-
+        
         self.present(activityViewController, animated: true, completion: nil)
     }
 }

--- a/Diary/Protocol/ShareDisplayable.swift
+++ b/Diary/Protocol/ShareDisplayable.swift
@@ -7,11 +7,11 @@
 
 import UIKit
 
-protocol ShareDiary {
+protocol ShareDisplayable {
     func shareDiary(_ diary: Diary?)
 }
 
-extension ShareDiary where Self: UIViewController {
+extension ShareDisplayable where Self: UIViewController {
     func shareDiary(_ diary: Diary?) {
         guard let diary,
               let title = diary.title,

--- a/Diary/View/DiaryListTableViewCell.swift
+++ b/Diary/View/DiaryListTableViewCell.swift
@@ -57,16 +57,12 @@ final class DiaryListTableViewCell: UITableViewCell {
         NSLayoutConstraint.activate([
             titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 5),
             titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
-            titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -40)
-        ])
-        
-        NSLayoutConstraint.activate([
+            titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -40),
+            
             dateLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 8),
             dateLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
-            dateLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -5)
-        ])
-        
-        NSLayoutConstraint.activate([
+            dateLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -5),
+            
             bodyLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 8),
             bodyLabel.leadingAnchor.constraint(equalTo: dateLabel.trailingAnchor, constant: 4),
             bodyLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -40),

--- a/README.md
+++ b/README.md
@@ -1,7 +1,227 @@
-## iOS 커리어 스타터 캠프
+# 📔 일기장
+프로젝트 기간: 2023.8.28 ~ 
 
-### 일기장 프로젝트 저장소
+## 📖 목차
+1. [🍀 소개](#1.)
+2. [👨‍💻 팀원](#2.)
+3. [📅 타임라인](#3.)
+4. [👀 시각화된 프로젝트 구조](#4.)
+5. [💻 실행 화면](#5.)
+6. [🪄 핵심 경험](#6.)
+7. [🧨 트러블 슈팅](#7.)
+8. [📚 참고 링크](#8.)
 
-- 이 저장소를 자신의 저장소로 fork하여 프로젝트를 진행합니다
-- 자신의 브랜치에 PR을 보내는지 꼭 확인한 후 PR을 보냅니다
+</br>
 
+<a id="1."></a></br>
+## 🍀 소개
+일기를 생성, 수정, 삭제할 수 있는 앱
+</br>
+
+<a id="2."></a></br>
+## 👨‍💻 팀원
+| Max | hamg |
+| :--------: | :--------: |
+| <Img src = "https://hackmd.io/_uploads/B1FqbcBAn.png" width="200" height="200"> |<Img src="https://hackmd.io/_uploads/BknBM9rC2.jpg" width="200" height="200"> |
+|[Github Profile](https://github.com/maxhyunm)|[Github Profile](https://github.com/hemg2) |
+
+
+</br>
+
+<a id="3."></a></br>
+## 📅 타임라인
+|날짜|내용|
+|:--:|--|
+|2023.08.28| `SwiftLint` 라이브러리 추가|
+|2023.08.29| `SwiftLint` 조건 변경 |
+|2023.08.30| `DiaryEntity` `CreateDiaryViewController `생성<br> `keyboard` `NotificationCenter` 생성 및 구현 | 
+|2023.09.01| `CoreData`: `Create` 구현|
+|2023.09.05| `CoreData`: `UpDate`, `Delete` 구현 <br> `Swipe` `share`, `delete` 구현 <br> `AlertController` 생성  |
+|2023.09.06| `CoreData`: `fetchDiary` 구현 |
+|2023.09.07| 개인 학습 및 README 작성 |
+
+</br>
+
+<a id="4."></a></br>
+## 👀 시각화된 프로젝트 구조
+### FileTree
+    ├── Diary
+    │   ├── Protocol
+    │   │   ├── AlertDisplayble.swift
+    │   │   └── ShareDiary.swift
+    │   ├── DataManager
+    │   │   └── CoreDataManager.swift
+    │   ├── Extension
+    │   │   └── DateFormatter+.swift
+    │   ├── Model
+    │   │   ├── Diary+CoreDataClass.swift
+    │   │   ├── Diary+CoreDataProperties.swift
+    │   │   ├── DecodingManager.swift
+    │   │   └── DiaryEntity.swift
+    │   ├── Error
+    │   │   └── DecodingError.swift
+    │   ├── Controller
+    │   │   ├── CreateDiaryViewController.swift
+    │   │   └── DiaryListViewController.swift
+    │   ├──  View
+    │   │   └── DiaryListTableViewCell.swift
+    │   ├── App
+    │   │   ├── AppDelegate.swift
+    │   │   └── SceneDelegate.swift
+    │   ├── Assets.xcassets
+    │   ├── Info.plist
+    │   └── Diary.xcdatamodeld
+    └── Diary.xcodeproj
+
+</br>
+
+<a id="5."></a></br>
+## 💻 실행 화면
+
+|작동 화면|
+|:--:|
+|<img src="https://hackmd.io/_uploads/SJkqEgUC3.gif" width="300" height="600"/>|
+
+</br>
+
+<a id="6."></a></br>
+## 🪄 핵심 경험
+#### 🌟 CoreData를 활용한 데이터 저장
+일기 데이터를 위한 저장소로 CoreData를 활용하였습니다.
+#### 🌟 Singleton 패턴을 활용한 CoreDataManager 구현
+데이터 처리를 위한 로직 전반을 Singleton 패턴으로 구현하여 앱 전역에서 활용 가능하도록 하였습니다.
+#### 🌟 NotificationCenter를 활용한 키보드 인식
+키보드 활성화 여부에 따라 뷰의 크기를 변경하여 커서 위치가 가려지지 않도록 NotificationCenter를 활용하였습니다.
+#### 🌟 여러 개의 생성자를 통한 상황별 데이터 전달
+상황에 따라 ViewController에서 다른 데이터를 표시해야 하는 경우에 대비해 생성자를 활용하였습니다.
+#### 🌟 Protocol과 Extension을 활용한 코드 분리
+Alert, Swipe 등 별개의 작업으로 분리할 수 있는 내용들은 Protocol과 Extension을 통해 분리하였습니다.
+
+</br>
+
+<a id="7."></a></br>
+## 🧨 트러블 슈팅
+
+### 1️⃣ **반복적인 날짜 포매팅 처리**
+🔒 **문제점** </br>
+ 일기 리스트 화면과 새로운 일기를 생성하는 화면에서 모두 아래와 같이 날짜 포매팅을 사용해야 하는 것을 알 수 있었습니다.
+```swift
+ private let formatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "ko_kr")
+    formatter.dateFormat = "yyyy년MM월dd일"
+    return formatter
+}()
+```
+동일한 코드가 두 개의 `ViewController`에서 반복되어 사용하고 있었으며
+반복되는 것을 막기 위해 해당 코드를 분리하고자 했습니다.
+</br></br>
+
+🔑 **해결방법** </br>
+저장 프로퍼티가 아닌 메서드로 사용하여 재사용성을 높히게 되었습니다.
+```swift
+extension DateFormatter {
+    func formatToString(from date: Date, with format: String) -> String {
+        self.dateFormat = format
+        
+        return self.string(from: date)
+    }
+}
+
+DateFormatter().formatToString(from: entity.createdAt, with: "YYYY년 MM월 dd일")
+```
+</br>
+
+### 2️⃣ **화면이 꺼질 때 자동 저장 처리**
+🔒 **문제점**</br>
+요구사항에 따르면 사용자가 화면을 벗어날 때마다 자동 저장을 진행해야 했습니다. 이를 구현하기 위해 처음에는 `CreateViewController`의 `viewWillDisappear` 메서드에서 저장처리를 진행할 수 있도록 작업했습니다.
+```swift
+override func viewWillDisappear(_ animated: Bool) {
+    super.viewWillDisappear(animated)
+    saveDiary()
+}
+```
+하지만 이렇게 하니 일기 삭제 처리를 한 뒤 뷰컨트롤러를 pop할 때에도 저장처리를 거치게 되어 오류가 발생하였습니다.
+</br></br>
+
+🔑 **해결방법**</br>
+`TextView`가 수정될 때마다 뷰컨트롤러가 가지고 있는 일기 객체의 내용을 바꿔주고, 저장이 필요한 순간에 `saveContext` 처리만 진행할 수 있도록 아래와 같이 구현하였습니다.
+```swift
+func textViewDidChange(_ textView: UITextView) {
+    let contents = textView.text.split(separator: "\n")
+    guard !contents.isEmpty,
+          let title = contents.first else { return }
+
+    let body = contents.dropFirst().joined(separator: "\n")
+
+    diary.title = "\(title)"
+    diary.body = body
+}
+```
+</br>
+
+### 3️⃣ **빈 일기가 저장되는 현상**
+🔒 **문제점(1)**</br>
+처음에는 키보드가 비활성화되면 무조건 내용을 저장하도록 구현을 하였습니다. 하지만 이렇게 하니, 신규 생성 버튼(+)을 누른 뒤 아무런 내용도 입력하지 않고 뒤로 가기 처리를 하면 제목과 내용이 모두 비어있는 일기가 생성이 되었습니다.
+```swift
+func textViewDidEndEditing(_ textView: UITextView) {
+    CoreDataManager.shared.saveContext()
+}
+```
+|빈일기 생성 화면|
+|:--:|
+|<img src="https://cdn.discordapp.com/attachments/1148871276677562388/1148871347871686706/3639304423dabd43.gif" width="200" height="400"/>|
+
+</br></br>
+
+🔑 **해결방법(1)**</br>
+빈 일기가 생성되는것을 막기 위해 title 이 없을 경우 저장 되지 않게 진행하였습니다.
+```swift
+func textViewDidEndEditing(_ textView: UITextView) {
+        let contents = textView.text.split(separator: "\n")
+        guard !contents.isEmpty else { return }
+        
+        CoreDataManager.shared.saveContext()
+    }
+```
+</br></br>
+🔒 **문제점(2)**</br>
+위의 처리를 통해 더 이상 데이터베이스에 빈 일기가 저장되지는 않았지만, saveContext 되지 않은 객체가 여전히 context 내부에 남아 일시적으로 빈 일기가 리스트에 보이는 현상이 생겼습니다. 
+```swift
+func readCoreData() {
+        do {
+            diaryList = try container.viewContext.fetch(Diary.fetchRequest())
+            tableView.reloadData()
+        } catch {
+           ....
+        }
+    }
+```
+</br></br>
+
+🔑 **해결방법(2)**</br>
+fetch해 온 일기들 중에 title이 비어있는 건은 걸러낼 수 있도록 filter 처리를 추가하였습니다.
+```swift
+ private func readCoreData() {
+        do {
+            let fetchedDiaries = try CoreDataManager.shared.fetchDiary()
+            diaryList = fetchedDiaries.filter { $0.title != nil }
+            tableView.reloadData()
+        } catch {
+           .....
+        }
+    }
+```
+</br>
+
+<a id="8."></a></br>
+## 📚 참고 링크
+- [Apple Developer Documentation: Adaptivity and Layout](https://developer.apple.com/design/human-interface-guidelines/layout)
+- [Apple Developer Documentation: DateFormatter](https://developer.apple.com/documentation/foundation/dateformatter)
+- [Apple Developer Documentation: UITextView](https://developer.apple.com/documentation/uikit/uitextview) 
+- [Apple Developer Documentation: Core Data](https://developer.apple.com/documentation/coredata) 
+- [Apple Developer Documentation: Making Apps with Core Data](https://developer.apple.com/videos/play/wwdc2019/230/)
+- [Apple Developer Documentation: NSFetchedResultsController](https://developer.apple.com/documentation/coredata/nsfetchedresultscontroller)
+- [Apple Developer Documentation: UITextViewDelegate](https://developer.apple.com/documentation/uikit/uitextviewdelegate)
+- [Apple Developer Documentation: UISwipeActionsConfiguration](https://developer.apple.com/documentation/uikit/uiswipeactionsconfiguration)
+</br>


### PR DESCRIPTION
> 일기장 [STEP 2] Hamg, maxhyunm

안녕하세요 그린!(@GREENOVER)
일기장 STEP 2 PR 올려드립니다.
코어 데이터 처리로 많이 헤맸던 것 같습니다😂
이번 스텝도 리뷰 잘 부탁드립니다!🙇‍

## 고민했던 점
### 🔹 Core Data 처리용 로직 위치
처음에는 `SceneDelegate` 또는 `AppDelegate`에 `PersistentContainer`와 `saveContext` 메서드를 두려고 했습니다. 하지만 이 두 가지 내용을 포함하여, CRUD 작업 전반과 관련된 내용을 별개의 타입으로 분리하여 `CoreDataManager`를 만들면 좀 더 깔끔히 관리할 수 있을 것 같다는 생각이 들었습니다. 이에 따라 아래와 같이 새로운 타입을 생성하였습니다.
Manager 타입은 하나의 인스턴스를 앱 전체가 공통적으로 사용하므로 싱글톤 처리를 하였습니다.
```swift
class CoreDataManager {
    static let shared = CoreDataManager()
    private init() {}
        
    func fetchDiary() throws -> [Diary] {
        ...
    }
    
    func createDiary() -> Diary {
        ...
    }
    
    func deleteDiary(_ diary: Diary?) {
        ...
    }
    
    // MARK: - Core Data stack
    lazy var persistentContainer: NSPersistentContainer = {
        ...
    }()

    func saveContext () {
        ...
    }
}
```

### 🔹 일기 생성/수정 처리 방식
일기 신규 생성과 기존 일기 수정 작업은 모두 `CreateDiaryViewController`를 통해 구현됩니다.
이때 신규/수정 여부를 구분하기 위해, 수정 작업인 경우에는 `init`을 통해 수정할 일기 인스턴스를 전달해줄 수 있도록 새로운 생성자를 추가하였습니다. 또한 신규 작업인 경우에는 `init`에서 uuid, 날짜만 입력된 새로운 `diary` 객체를 생성하도록 하였습니다.
```swift
 init() {
     self.diary = CoreDataManager.shared.createDiary()
     self.isNew = true
     super.init(nibName: nil, bundle: nil)
 }
 
 init(_ diary: Diary) {
     self.diary = diary
     self.isNew = false
     super.init(nibName: nil, bundle: nil)
 }
```

### 🔹 일기 자동저장 구현 방식
요구사항에 따른 자동저장 시기는 다음과 같았습니다.
- 사용자가 입력을 멈추는 경우(키보드가 사라지는 경우)
- 앱이 백그라운드로 진입하는 경우
- 이전 화면(리스트 화면)으로 이동하는 경우

이에 따라 `UITextViewDelegate`의 `textViewDidEndEditing` 메서드를 활용하여 다음과 같이 구현하였습니다.
```swift
func textViewDidEndEditing(_ textView: UITextView) {
    let contents = textView.text.split(separator: "\n")
    guard !contents.isEmpty else { return }

    CoreDataManager.shared.saveContext()
}
```
위의 작업을 통해 키보드 비활성화와 화면 뒤로가기 작업시에는 자동으로 내용을 title / body 로 분리하여 저장할 수 있었습니다.
하지만 앱이 백그라운드에 진입하는 경우는 `SceneDelegate`의 `sceneDidEnterBackground` 메서드를 통해 작업하는 것으로 알고 있어, `CreateDiaryViewController` 내부의 textView 내용에 접근하는 방법을 찾기가 어려웠습니다. 싱글톤으로 만들어진 `CoreDataManager`의 `saveContext`메서드를 통해 해당 일기 객체를 코어데이터에 저장할 수는 있었지만, 현재 작성된 일기 내용을 title과 body로 나누어 업데이트하는 작업이 불가능했습니다. 
이를 해결하기 위해 처음에는 `CreateViewController`의 `viewWillDisappear` 메서드에서 저장처리를 진행할 수 있도록 구현해 보았습니다.
```swift
override func viewWillDisappear(_ animated: Bool) {
    super.viewWillDisappear(animated)
    saveDiary()
}
```
하지만 이렇게 하니 일기 삭제 처리를 한 뒤 뷰컨트롤러를 pop할 때에도 저장처리를 거치게 되어, 오류를 피하려다 보니 오히려 로직이 복잡해졌습니다.
때문에 저희는 `TextView`가 수정될 때마다 뷰컨트롤러가 가지고 있는 일기 객체의 내용을 바꿔주고, 저장이 필요한 순간에 `saveContext` 처리만 진행할 수 있도록 아래와 같이 구현하였습니다.
```swift
func textViewDidChange(_ textView: UITextView) {
    let contents = textView.text.split(separator: "\n")
    guard !contents.isEmpty,
          let title = contents.first else { return }

    let body = contents.dropFirst().joined(separator: "\n")

    diary.title = "\(title)"
    diary.body = body
}
```

### 🔹 alert과 swipe 코드 분리
반복적인 alertController 생성 작업, 그리고 swipe 코드를 뷰컨트롤러에서 조금이라도 분리하면 좋을 것 같아 protocol과 extension을 활용하였습니다.
- `Alert` 분리전 코드
```swift
private func showDeleteConfirmation() {
    let alertController = UIAlertController(title: "진짜요?", message: "정말로 삭제하시겠습니까?", preferredStyle: .alert)
    
    let cancelAction = UIAlertAction(title: "취소", style: .cancel, handler: nil)
    alertController.addAction(cancelAction)
    
    let deleteAction = UIAlertAction(title: "삭제", style: .destructive) { [weak self] _ in
        guard let self else { return }
        self.performDelete()
    }
    alertController.addAction(deleteAction)
    
    present(alertController, animated: true, completion: nil)
}
```

- 분리 후 코드
```swift
protocol AlertDisplayable {
    func showAlert(title: String?, message: String?, actions: [UIAlertAction])
}

extension AlertDisplayable where Self: UIViewController {
    func showAlert(title: String?, message: String?, actions: [UIAlertAction]) {
        let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
        actions.forEach { alertController.addAction($0) }
        present(alertController, animated: true, completion: nil)
    }
}
```
- 구현부 코드
```swift
private func showDeleteConfirmation() {
        let cancelAction = UIAlertAction(title: "취소", style: .cancel, handler: nil)
        let deleteAction = UIAlertAction(title: "삭제", style: .destructive) { [weak self] _ in
            self?.performDelete()
        }
        
        showAlert(title: "진짜요?", message: "정말로 삭제하시겠습니까?", actions: [cancelAction, deleteAction])
    }
```


### 🔹 일기 리스트 새로고침 시점
처음에는 `DiaryListViewController`와 `CreateDiaryViewController`를 `delegate`로 연결하여 생성화면이 pop될 때 리스트 화면의 `readCoreData` 메서드를 호출하도록 구현하였습니다. 하지만 이보다는 뷰의 생명주기를 활용하는 편이 더 깔끔할 것 같다는 생각이 들었습니다. 이에 따라 `viewWillAppear` 메서드에서 아래와 같이 처리해주었습니다.
```swift
override func viewWillAppear(_ animated: Bool) {
    super.viewWillAppear(animated)

    readCoreData()
}
```

## 조언을 얻고 싶은 점
### 빈 화면에서 뒤로가기를 눌렀을 때의 처리방법
요구사항에 따르면, 일기장의 + 버튼을 눌러 새 일기장을 생성했을 경우 키보드가 자동으로 올라오게 됩니다. 그리고 뒤로가기 처리를 하거나 백그라운드 상태로 변환되는 등 현재 화면에서 벗어나면 작업중인 내용이 자동으로 저장이 되어야 합니다. 그렇다면 + 버튼을 눌렀다가 아무런 내용을 작성하지 않은 채 뒤로가기를 눌러도 제목/내용이 없는 빈 일기가 생성되는 것이 맞을까요? 저희는 이 부분이 조금 어색한 것 같아서 아예 비어있는 내용은 context에서 save처리를 하지 않도록 만들어두었습니다. 그린의 의견이 궁금합니다😭

---